### PR TITLE
Feature/survey fix race

### DIFF
--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -373,9 +373,6 @@ func (s *Surveyor) FindPeers(ctx context.Context, ns string, opt ...discovery.Op
 			}
 		}()
 
-		timer := time.NewTimer(opts.Ttl)
-		defer timer.Stop()
-
 		for {
 			select {
 			case rec, ok := <-finder:
@@ -395,8 +392,6 @@ func (s *Surveyor) FindPeers(ctx context.Context, ns string, opt ...discovery.Op
 					}
 				}
 
-			case <-timer.C:
-				return
 			case <-ctx.Done():
 				return
 			case <-s.ctx.Done():

--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -135,9 +135,25 @@ func New(h host.Host, addr net.Addr, opt ...Option) (*Surveyor, error) {
 		return nil, err
 	}
 
+	// sync - wait until local record is set
+	select {
+	case v := <-sub.Out():
+		s.setLocalRecord(v.(event.EvtLocalAddressesUpdated))
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	// Update local record aysnchronously
+	go func() {
+		for v := range sub.Out() {
+			s.setLocalRecord(v.(event.EvtLocalAddressesUpdated))
+		}
+	}()
+
 	go func() {
 		defer lconn.Close()
 		defer dconn.Close()
+		defer sub.Close()
 		defer cancel()
 
 		ticker := time.NewTicker(time.Second)
@@ -147,13 +163,6 @@ func New(h host.Host, addr net.Addr, opt ...Option) (*Surveyor, error) {
 
 		for {
 			select {
-			case ev := <-sub.Out():
-				e := ev.(event.EvtLocalAddressesUpdated).SignedPeerRecord
-				r, _ := e.Record()
-				rec := r.(*peer.PeerRecord)
-				s.e.Store(e)
-				s.rec.Store(rec)
-
 			case m := <-recv:
 				if err := s.handleMessage(ctx, m); err != nil {
 					s.log.WithError(err).Debug("dropped message")
@@ -205,6 +214,13 @@ func (s *Surveyor) Close() error {
 	defer s.cancel()
 	err, _ := s.err.Load().(error)
 	return err
+}
+
+func (s *Surveyor) setLocalRecord(ev event.EvtLocalAddressesUpdated) {
+	r, _ := ev.SignedPeerRecord.Record()
+	rec := r.(*peer.PeerRecord)
+	s.e.Store(ev.SignedPeerRecord)
+	s.rec.Store(rec)
 }
 
 func (s *Surveyor) handleMessage(ctx context.Context, m *capnp.Message) error {

--- a/pkg/boot/survey/survey_test.go
+++ b/pkg/boot/survey/survey_test.go
@@ -7,9 +7,8 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/discovery"
-	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wetware/casm/pkg/boot/survey"
 	mx "github.com/wetware/matrix/pkg"
@@ -18,11 +17,47 @@ import (
 const (
 	testNs        = "casm/survey"
 	advertiseTTL  = time.Minute
-	findPeersTTL  = 10 * time.Millisecond
 	multicastAddr = "224.0.1.241:3037"
 )
 
+func TestTransport(t *testing.T) {
+	t.Parallel()
+
+	var tpt survey.Transport
+
+	addr, err := net.ResolveUDPAddr("udp4", multicastAddr)
+	require.NoError(t, err)
+
+	lconn, err := tpt.Listen(addr)
+	require.NoError(t, err)
+	require.NotNil(t, lconn)
+	defer lconn.Close()
+
+	dconn, err := tpt.Dial(addr)
+	require.NoError(t, err)
+	require.NotNil(t, dconn)
+	defer dconn.Close()
+
+	ch := make(chan []byte, 1)
+	go func() {
+		defer close(ch)
+		var buf [4]byte
+		n, _, err := lconn.ReadFrom(buf[:])
+		require.NoError(t, err)
+		ch <- buf[:n]
+	}()
+
+	n, err := dconn.WriteTo([]byte("test"), addr)
+	require.NoError(t, err)
+	assert.Equal(t, len("test"), n)
+
+	b := <-ch
+	require.Equal(t, "test", string(b))
+}
+
 func TestDiscover(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -31,8 +66,6 @@ func TestDiscover(t *testing.T) {
 	defer h1.Close()
 	h2 := sim.MustHost(ctx)
 	defer h2.Close()
-	waitReady(h1)
-	waitReady(h2)
 
 	addr, _ := net.ResolveUDPAddr("udp4", multicastAddr)
 
@@ -47,63 +80,22 @@ func TestDiscover(t *testing.T) {
 	a1.Advertise(ctx, testNs, discovery.TTL(advertiseTTL))
 	a2.Advertise(ctx, testNs, discovery.TTL(advertiseTTL))
 
-	infos := make([]peer.AddrInfo, 0)
-	for i := uint8(1); i < uint8(255) && len(infos) == 0; i += 5 {
-		finder, err := a1.FindPeers(ctx, testNs, discovery.TTL(findPeersTTL), survey.WithDistance(i))
-		require.NoError(t, err)
-
-		for info := range finder {
-			infos = append(infos, info)
-		}
-	}
-
-	require.Len(t, infos, 1)
-	require.Equal(t, infos[0].ID, h2.ID())
-}
-
-func TestDiscoverNone(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sim := mx.New(ctx)
-	h1 := sim.MustHost(ctx)
-	defer h1.Close()
-	h2 := sim.MustHost(ctx)
-	defer h2.Close()
-	waitReady(h1)
-	waitReady(h2)
-
-	addr, _ := net.ResolveUDPAddr("udp4", multicastAddr)
-
-	a1, err := survey.New(h1, addr)
+	finder, err := a1.FindPeers(ctx, testNs)
 	require.NoError(t, err)
-	defer a1.Close()
 
-	a2, err := survey.New(h2, addr)
-	require.NoError(t, err)
-	defer a2.Close()
-
-	infos := make([]peer.AddrInfo, 0)
-	for i := uint8(1); i < uint8(255) && len(infos) == 0; i += 5 {
-		finder, err := a1.FindPeers(ctx, testNs, discovery.TTL(findPeersTTL), survey.WithDistance(i))
-		require.NoError(t, err)
-
-		for info := range finder {
-			infos = append(infos, info)
-		}
-	}
-
-	require.Len(t, infos, 0)
+	info := <-finder
+	require.Equal(t, info, *host.InfoFromHost(h2))
 }
 
 func TestClose(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	sim := mx.New(ctx)
 	h1 := sim.MustHost(ctx)
 	defer h1.Close()
-	waitReady(h1)
 
 	addr, _ := net.ResolveUDPAddr("udp4", multicastAddr)
 
@@ -117,14 +109,4 @@ func TestClose(t *testing.T) {
 
 	_, err = a1.Advertise(ctx, testNs, discovery.TTL(advertiseTTL))
 	require.Error(t, err, "closed")
-}
-
-func waitReady(h host.Host) {
-	sub, err := h.EventBus().Subscribe(new(event.EvtLocalAddressesUpdated))
-	if err != nil {
-		panic(err)
-	}
-	defer sub.Close()
-
-	<-sub.Out()
 }


### PR DESCRIPTION
- [x] Fix panic due to race condition where empty `atomic.Value` is loaded and type-asserted.
- [x] Remove unneeded timer in `FindPeers`
- [x] Remove `discovery.TTL` from calls to `FindPeers` in tests
- [x] Fix deadlock in unit tests