### PR TITLE
Refactor/boot

### DIFF
--- a/internal/cmd/discover/generate.go
+++ b/internal/cmd/discover/generate.go
@@ -12,6 +12,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
 	"github.com/wetware/casm/pkg/boot/socket"
+	"github.com/wetware/casm/pkg/util/tracker"
 )
 
 var (
@@ -75,12 +76,8 @@ func generate(c *cli.Context) (*record.Envelope, error) {
 		return nil, err
 	}
 
-	if err = cache.Reset(e); err != nil {
-		return nil, err
-	}
-
 	if c.Bool("resp") {
-		return cache.LoadResponse(seal, c.String("ns"))
+		return cache.LoadResponse(seal, tracker.StaticRecordProvider{Envelope: e}, c.String("ns"))
 	}
 
 	if c.IsSet("dist") {

--- a/internal/cmd/discover/generate.go
+++ b/internal/cmd/discover/generate.go
@@ -54,7 +54,7 @@ func genpayload() *cli.Command {
 }
 
 func generate(c *cli.Context) (*record.Envelope, error) {
-	cache, err := socket.NewRecordCache(8)
+	cache, err := socket.NewCache(8)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/discover/generate.go
+++ b/internal/cmd/discover/generate.go
@@ -15,9 +15,8 @@ import (
 )
 
 var (
-	pk    crypto.PrivKey
-	id    peer.ID
-	cache = socket.NewRecordCache(8)
+	pk crypto.PrivKey
+	id peer.ID
 )
 
 func genpayload() *cli.Command {
@@ -54,6 +53,11 @@ func genpayload() *cli.Command {
 }
 
 func generate(c *cli.Context) (*record.Envelope, error) {
+	cache, err := socket.NewRecordCache(8)
+	if err != nil {
+		return nil, err
+	}
+
 	pk, err := privkey()
 	if err != nil {
 		return nil, err

--- a/pkg/boot/crawl/crawl.go
+++ b/pkg/boot/crawl/crawl.go
@@ -42,14 +42,16 @@ var (
 
 type Crawler struct {
 	log     log.Logger
-	lim     *socket.RateLimiter
-	sock    *socket.Socket
 	host    host.Host
-	iter    Strategy
-	cache   *socket.RequestResponseCache
-	done    <-chan struct{}
-	cancel  context.CancelFunc
-	tracker *tracker.HostTracker
+	tracker *tracker.HostAddrTracker
+
+	lim   *socket.RateLimiter
+	sock  *socket.Socket
+	cache *socket.RequestResponseCache
+	iter  Strategy
+
+	done   <-chan struct{}
+	cancel context.CancelFunc
 }
 
 func New(h host.Host, conn net.PacketConn, opt ...Option) *Crawler {

--- a/pkg/boot/crawl/crawl.go
+++ b/pkg/boot/crawl/crawl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p-core/record"
+	"go.uber.org/multierr"
 
 	"github.com/lthibault/log"
 	ma "github.com/multiformats/go-multiaddr"
@@ -83,7 +84,7 @@ func New(h host.Host, conn net.PacketConn, opt ...Option) *Crawler {
 
 func (c *Crawler) Close() error {
 	c.cancel()
-	return c.sock.Close()
+	return multierr.Combine(c.tracker.Close(), c.sock.Close())
 }
 
 func (c *Crawler) requestHandler(ctx context.Context) func(socket.Request, net.Addr) {

--- a/pkg/boot/crawl/crawl.go
+++ b/pkg/boot/crawl/crawl.go
@@ -69,7 +69,7 @@ func New(h host.Host, conn net.PacketConn, opt ...Option) *Crawler {
 		option(c)
 	}
 
-	c.tracker.AddCallback(c.cache.Reset)
+	c.tracker.AddCallback(func(*peer.PeerRecord) { c.cache.Reset() })
 
 	c.sock = socket.New(conn, socket.Protocol{
 		Validate:      socket.BasicValidator(h.ID()),

--- a/pkg/boot/crawl/crawl.go
+++ b/pkg/boot/crawl/crawl.go
@@ -72,6 +72,7 @@ func New(h host.Host, conn net.PacketConn, opt ...Option) *Crawler {
 		// RateLimiter:   c.lim,  // FIXME:  blocks reads when waiting to write
 		Cache: c.cache,
 	})
+	c.sock.Start()
 
 	return c
 }

--- a/pkg/boot/crawl/crawl.go
+++ b/pkg/boot/crawl/crawl.go
@@ -36,8 +36,6 @@ func init() {
 }
 
 var (
-	ErrClosed = errors.New("closed")
-
 	// ErrCIDROverflow is returned when a CIDR block is too large.
 	ErrCIDROverflow = errors.New("CIDR overflow")
 )
@@ -48,7 +46,7 @@ type Crawler struct {
 	sock    *socket.Socket
 	host    host.Host
 	iter    Strategy
-	cache   *socket.RecordCache
+	cache   *socket.RequestResponseCache
 	done    <-chan struct{}
 	cancel  context.CancelFunc
 	tracker *tracker.HostTracker

--- a/pkg/boot/crawl/option.go
+++ b/pkg/boot/crawl/option.go
@@ -43,7 +43,7 @@ func WithCacheSize(size int) Option {
 	}
 
 	return func(c *Crawler) {
-		c.cache, _ = socket.NewRecordCache(size)
+		c.cache, _ = socket.NewCache(size)
 	}
 }
 

--- a/pkg/boot/crawl/option.go
+++ b/pkg/boot/crawl/option.go
@@ -43,7 +43,7 @@ func WithCacheSize(size int) Option {
 	}
 
 	return func(c *Crawler) {
-		c.cache = socket.NewRecordCache(size)
+		c.cache, _ = socket.NewRecordCache(size)
 	}
 }
 

--- a/pkg/boot/socket/cache.go
+++ b/pkg/boot/socket/cache.go
@@ -57,12 +57,12 @@ func (c *RequestResponseCache) LoadSurveyRequest(seal Sealer, id peer.ID, ns str
 // LoadResponse searches the cache for a signed response packet for ns
 // and returns it, if found. Else, it creates and signs a new response
 // packet and adds it to the cache.
-func (c *RequestResponseCache) LoadResponse(seal Sealer, prov tracker.RecordProvider, ns string) (*record.Envelope, error) {
+func (c *RequestResponseCache) LoadResponse(seal Sealer, recProv tracker.RecordProvider, ns string) (*record.Envelope, error) {
 	if v, ok := c.cache.Get(keyResponse(ns)); ok {
 		return v.(*record.Envelope), nil
 	}
 
-	return c.storeCache(response(prov.Record()), seal, ns)
+	return c.storeCache(response(recProv.Record()), seal, ns)
 }
 
 type bindFunc func(boot.Packet) error

--- a/pkg/boot/socket/socket.go
+++ b/pkg/boot/socket/socket.go
@@ -40,7 +40,7 @@ type Socket struct {
 	time time.Time
 	sub  event.Subscription
 
-	cache *RecordCache
+	cache *RequestResponseCache
 
 	prot Protocol
 }

--- a/pkg/boot/survey/option.go
+++ b/pkg/boot/survey/option.go
@@ -32,7 +32,7 @@ func WithCacheSize(size int) Option {
 	}
 
 	return func(s *Surveyor) {
-		s.cache, _ = socket.NewRecordCache(size)
+		s.cache, _ = socket.NewCache(size)
 	}
 }
 

--- a/pkg/boot/survey/option.go
+++ b/pkg/boot/survey/option.go
@@ -32,7 +32,7 @@ func WithCacheSize(size int) Option {
 	}
 
 	return func(s *Surveyor) {
-		s.cache = socket.NewRecordCache(size)
+		s.cache, _ = socket.NewRecordCache(size)
 	}
 }
 

--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lthibault/log"
 
 	"github.com/wetware/casm/pkg/boot/socket"
+	"github.com/wetware/casm/pkg/util/tracker"
 )
 
 var ErrClosed = errors.New("closed")
@@ -24,13 +25,14 @@ var ErrClosed = errors.New("closed")
 // Surveyor discovers peers through a surveyor/respondent multicast
 // protocol.
 type Surveyor struct {
-	log    log.Logger
-	lim    *socket.RateLimiter
-	sock   *socket.Socket
-	host   host.Host
-	cache  *socket.RecordCache
-	done   <-chan struct{}
-	cancel context.CancelFunc
+	log     log.Logger
+	lim     *socket.RateLimiter
+	sock    *socket.Socket
+	host    host.Host
+	cache   *socket.RecordCache
+	done    <-chan struct{}
+	cancel  context.CancelFunc
+	tracker *tracker.HostTracker
 }
 
 // New surveyor.  The supplied PacketConn SHOULD be bound to a multicast
@@ -39,21 +41,23 @@ func New(h host.Host, conn net.PacketConn, opt ...Option) *Surveyor {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	s := &Surveyor{
-		host:   h,
-		done:   ctx.Done(),
-		cancel: cancel,
+		host:    h,
+		done:    ctx.Done(),
+		cancel:  cancel,
+		tracker: tracker.New(h),
 	}
 
 	for _, option := range withDefaults(opt) {
 		option(s)
 	}
 
+	s.tracker.AddCallback(s.cache.Reset)
+
 	s.sock = socket.New(conn, socket.Protocol{
 		Validate:      socket.BasicValidator(h.ID()),
 		HandleError:   socket.BasicErrHandler(ctx, s.log),
 		HandleRequest: s.requestHandler(ctx),
 		// RateLimiter:   s.lim,  // FIXME:  blocks reads when waiting to write
-		Cache: s.cache,
 	})
 	s.sock.Start()
 
@@ -90,7 +94,7 @@ func (s *Surveyor) requestHandler(ctx context.Context) func(socket.Request, net.
 		}
 
 		if s.sock.Tracking(ns) {
-			e, err := s.cache.LoadResponse(s.sealer(), ns)
+			e, err := s.cache.LoadResponse(s.sealer(), s.tracker, ns)
 			if err != nil {
 				s.log.WithError(err).Error("error loading response from cache")
 				return
@@ -114,7 +118,13 @@ func (s *Surveyor) Advertise(ctx context.Context, ns string, opt ...discovery.Op
 		return 0, err
 	}
 
-	return opts.Ttl, s.sock.Track(ctx, s.host, ns, opts.Ttl)
+	if err := s.tracker.Ensure(ctx); err != nil {
+		return 0, err
+	}
+
+	s.sock.Track(ctx, s.host, ns, opts.Ttl)
+
+	return opts.Ttl, nil
 }
 
 func (s *Surveyor) FindPeers(ctx context.Context, ns string, opt ...discovery.Option) (<-chan peer.AddrInfo, error) {

--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -26,13 +26,15 @@ var ErrClosed = errors.New("closed")
 // protocol.
 type Surveyor struct {
 	log     log.Logger
-	lim     *socket.RateLimiter
-	sock    *socket.Socket
 	host    host.Host
-	cache   *socket.RequestResponseCache
-	done    <-chan struct{}
-	cancel  context.CancelFunc
-	tracker *tracker.HostTracker
+	tracker *tracker.HostAddrTracker
+
+	lim   *socket.RateLimiter
+	sock  *socket.Socket
+	cache *socket.RequestResponseCache
+
+	done   <-chan struct{}
+	cancel context.CancelFunc
 }
 
 // New surveyor.  The supplied PacketConn SHOULD be bound to a multicast

--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -54,7 +54,7 @@ func New(h host.Host, conn net.PacketConn, opt ...Option) *Surveyor {
 		option(s)
 	}
 
-	s.tracker.AddCallback(s.cache.Reset)
+	s.tracker.AddCallback(func(*peer.PeerRecord) { s.cache.Reset() })
 
 	s.sock = socket.New(conn, socket.Protocol{
 		Validate:      socket.BasicValidator(h.ID()),

--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -55,6 +55,7 @@ func New(h host.Host, conn net.PacketConn, opt ...Option) *Surveyor {
 		// RateLimiter:   s.lim,  // FIXME:  blocks reads when waiting to write
 		Cache: s.cache,
 	})
+	s.sock.Start()
 
 	return s
 }

--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p-core/record"
+	"go.uber.org/multierr"
 
 	"github.com/lthibault/log"
 
@@ -68,7 +69,7 @@ func New(h host.Host, conn net.PacketConn, opt ...Option) *Surveyor {
 
 func (s *Surveyor) Close() error {
 	s.cancel()
-	return s.sock.Close()
+	return multierr.Combine(s.tracker.Close(), s.sock.Close())
 }
 
 func (s *Surveyor) requestHandler(ctx context.Context) func(socket.Request, net.Addr) {

--- a/pkg/boot/survey/survey.go
+++ b/pkg/boot/survey/survey.go
@@ -29,7 +29,7 @@ type Surveyor struct {
 	lim     *socket.RateLimiter
 	sock    *socket.Socket
 	host    host.Host
-	cache   *socket.RecordCache
+	cache   *socket.RequestResponseCache
 	done    <-chan struct{}
 	cancel  context.CancelFunc
 	tracker *tracker.HostTracker

--- a/pkg/boot/survey/survey_test.go
+++ b/pkg/boot/survey/survey_test.go
@@ -138,9 +138,9 @@ func TestFindPeers(t *testing.T) {
 	require.Equal(t, 1, peersAmount)
 }
 
-func newTestTable(t *testing.T, N int) []test {
+func newTestTable(t *testing.T, N int) []*test {
 	var (
-		tt  = make([]test, N)
+		tt  = make([]*test, N)
 		err error
 	)
 
@@ -160,7 +160,7 @@ func newTestTable(t *testing.T, N int) []test {
 	return tt
 }
 
-func closeTestTable(tt []test) {
+func closeTestTable(tt []*test) {
 	for _, t := range tt {
 		t.h.Close()
 	}
@@ -199,7 +199,7 @@ func readIncomingRequest(request []byte, from net.Addr) func([]byte) (int, net.A
 	}
 }
 
-func loadRequest(t test, ns string, distance uint8) ([]byte, error) {
+func loadRequest(t *test, ns string, distance uint8) ([]byte, error) {
 	request, err := t.c.LoadSurveyRequest(sealer(t.h), t.h.ID(), ns, distance)
 	if err != nil {
 		return nil, err
@@ -207,8 +207,8 @@ func loadRequest(t test, ns string, distance uint8) ([]byte, error) {
 	return request.Marshal()
 }
 
-func loadResponse(t test, ns string) ([]byte, error) {
-	response, err := t.c.LoadResponse(sealer(t.h), t.t, ns)
+func loadResponse(t *test, ns string) ([]byte, error) {
+	response, err := t.c.LoadResponse(sealer(t.h), &t.t, ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/boot/survey/survey_test.go
+++ b/pkg/boot/survey/survey_test.go
@@ -23,7 +23,7 @@ import (
 type test struct {
 	h host.Host
 	c *socket.RecordCache
-	t tracker.HostTracker
+	t *tracker.HostTracker
 }
 
 func TestClose(t *testing.T) {
@@ -138,9 +138,9 @@ func TestFindPeers(t *testing.T) {
 	require.Equal(t, 1, peersAmount)
 }
 
-func newTestTable(t *testing.T, N int) []*test {
+func newTestTable(t *testing.T, N int) []test {
 	var (
-		tt  = make([]*test, N)
+		tt  = make([]test, N)
 		err error
 	)
 
@@ -154,13 +154,13 @@ func newTestTable(t *testing.T, N int) []*test {
 		tt[i].c, err = socket.NewRecordCache(2)
 		require.NoError(t, err)
 
-		tt[i].t = *tracker.New(tt[i].h)
+		tt[i].t = tracker.New(tt[i].h)
 		tt[i].t.Ensure(context.Background())
 	}
 	return tt
 }
 
-func closeTestTable(tt []*test) {
+func closeTestTable(tt []test) {
 	for _, t := range tt {
 		t.h.Close()
 	}
@@ -199,7 +199,7 @@ func readIncomingRequest(request []byte, from net.Addr) func([]byte) (int, net.A
 	}
 }
 
-func loadRequest(t *test, ns string, distance uint8) ([]byte, error) {
+func loadRequest(t test, ns string, distance uint8) ([]byte, error) {
 	request, err := t.c.LoadSurveyRequest(sealer(t.h), t.h.ID(), ns, distance)
 	if err != nil {
 		return nil, err
@@ -207,8 +207,8 @@ func loadRequest(t *test, ns string, distance uint8) ([]byte, error) {
 	return request.Marshal()
 }
 
-func loadResponse(t *test, ns string) ([]byte, error) {
-	response, err := t.c.LoadResponse(sealer(t.h), &t.t, ns)
+func loadResponse(t test, ns string) ([]byte, error) {
+	response, err := t.c.LoadResponse(sealer(t.h), t.t, ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/boot/survey/survey_test.go
+++ b/pkg/boot/survey/survey_test.go
@@ -23,7 +23,7 @@ import (
 type test struct {
 	h host.Host
 	c *socket.RequestResponseCache
-	t *tracker.HostTracker
+	t *tracker.HostAddrTracker
 }
 
 func TestClose(t *testing.T) {

--- a/pkg/boot/survey/survey_test.go
+++ b/pkg/boot/survey/survey_test.go
@@ -163,6 +163,7 @@ func newTestTable(t *testing.T, N int) []test {
 func closeTestTable(tt []test) {
 	for _, t := range tt {
 		t.h.Close()
+		t.t.Close()
 	}
 }
 

--- a/pkg/boot/survey/survey_test.go
+++ b/pkg/boot/survey/survey_test.go
@@ -1,201 +1,219 @@
 package survey_test
 
-// import (
-// 	"context"
-// 	"net"
-// 	"testing"
-// 	"time"
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
 
-// 	"capnproto.org/go/capnp/v3"
-// 	"github.com/libp2p/go-libp2p"
-// 	"github.com/libp2p/go-libp2p-core/discovery"
-// 	"github.com/libp2p/go-libp2p-core/event"
-// 	"github.com/libp2p/go-libp2p-core/host"
-// 	"github.com/libp2p/go-libp2p-core/record"
-// 	inproc "github.com/lthibault/go-libp2p-inproc-transport"
+	"github.com/golang/mock/gomock"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"github.com/libp2p/go-libp2p-core/event"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/record"
+	inproc "github.com/lthibault/go-libp2p-inproc-transport"
+	"github.com/stretchr/testify/require"
+	mock_net "github.com/wetware/casm/internal/mock/net"
+	"github.com/wetware/casm/pkg/boot/socket"
+	"github.com/wetware/casm/pkg/boot/survey"
+)
 
-// 	"github.com/golang/mock/gomock"
-// 	"github.com/stretchr/testify/assert"
-// 	"github.com/stretchr/testify/require"
-// 	mock_net "github.com/wetware/casm/internal/mock/net"
+type test struct {
+	h host.Host
+	c *socket.RecordCache
+}
 
-// 	"github.com/wetware/casm/internal/api/boot"
-// 	"github.com/wetware/casm/pkg/boot/survey"
-// )
+func TestClose(t *testing.T) {
+	t.Parallel()
 
-// const (
-// 	testNs       = "casm/survey"
-// 	advertiseTTL = time.Minute
-// )
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-// func TestTransport(t *testing.T) {
-// 	t.Parallel()
+	h, err := newTestHost()
+	require.NoError(t, err)
+	defer h.Close()
 
-// 	var tpt survey.MulticastTransport
+	conn := mock_net.NewMockPacketConn(ctrl)
 
-// 	// Change port in order to avoid conflicts between parallel tests.
-// 	const multicastAddr = "228.8.8.8:8823"
-// 	addr, err := net.ResolveUDPAddr("udp4", multicastAddr)
-// 	require.NoError(t, err)
+	conn.EXPECT().Close().Times(1)
+	conn.EXPECT().ReadFrom(gomock.Any()).AnyTimes()
 
-// 	lconn, err := tpt.Listen(addr)
-// 	require.NoError(t, err)
-// 	require.NotNil(t, lconn)
-// 	defer lconn.Close()
+	surveyor := survey.New(h, conn)
+	surveyor.Close()
+}
 
-// 	dconn, err := tpt.Dial(addr)
-// 	require.NoError(t, err)
-// 	require.NotNil(t, dconn)
-// 	defer dconn.Close()
+func TestAdvertise(t *testing.T) {
+	t.Parallel()
 
-// 	ch := make(chan []byte, 1)
-// 	go func() {
-// 		defer close(ch)
-// 		var buf [4]byte
-// 		n, _, err := lconn.ReadFrom(buf[:])
-// 		require.NoError(t, err)
-// 		ch <- buf[:n]
-// 	}()
+	const (
+		N  = 2
+		ns = "test-advertise"
+	)
 
-// 	n, err := dconn.WriteTo([]byte("test"), addr)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, len("test"), n)
+	var (
+		err  error
+		addr = &net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 8822,
+		}
+	)
 
-// 	b := <-ch
-// 	require.Equal(t, "test", string(b))
-// }
+	tt := newTestTable(t, N)
+	defer closeTestTable(tt)
 
-// func TestSurveyor(t *testing.T) {
-// 	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-// 	ctx, cancel := context.WithCancel(context.Background())
-// 	defer cancel()
+	conn := mock_net.NewMockPacketConn(ctrl)
 
-// 	ctrl := gomock.NewController(t)
-// 	defer ctrl.Finish()
+	request, err := loadRequest(tt[1].c, tt[1].h, ns, 255)
+	require.NoError(t, err)
 
-// 	h := newTestHost()
-// 	defer h.Close()
+	response, err := loadResponse(tt[0].c, tt[0].h, ns)
+	require.NoError(t, err)
 
-// 	sub, err := h.EventBus().Subscribe(new(event.EvtLocalAddressesUpdated))
-// 	require.NoError(t, err, "must subscribe to address updates")
-// 	defer sub.Close()
-// 	e := (<-sub.Out()).(event.EvtLocalAddressesUpdated).SignedPeerRecord
+	conn.EXPECT().ReadFrom(gomock.Any()).DoAndReturn(readIncomingRequest(request, addr)).MinTimes(1)
+	conn.EXPECT().WriteTo(response, addr).MinTimes(1)
+	conn.EXPECT().Close().Times(1)
 
-// 	mockTransport := survey.MulticastTransport{
-// 		DialFunc: func(net.Addr) (net.PacketConn, error) {
-// 			conn := mock_net.NewMockPacketConn(ctrl)
-// 			// Expect a single call to Close
-// 			conn.EXPECT().
-// 				Close().
-// 				Return(error(nil)).
-// 				Times(1)
+	surveyor := survey.New(tt[0].h, conn)
+	defer surveyor.Close()
 
-// 			// Expect a single REQUEST packet to be issued.
-// 			conn.EXPECT().
-// 				WriteTo(gomock.AssignableToTypeOf([]byte{}), gomock.AssignableToTypeOf(net.Addr(new(net.UDPAddr)))).
-// 				Return(0, nil). // n not checked by sender
-// 				Times(1)
+	surveyor.Advertise(context.Background(), ns)
 
-// 			return conn, nil
-// 		},
-// 		ListenFunc: func(net.Addr) (net.PacketConn, error) {
-// 			conn := mock_net.NewMockPacketConn(ctrl)
-// 			// Expect a single call to Close
-// 			conn.EXPECT().
-// 				Close().
-// 				Return(error(nil)).
-// 				Times(1)
+	time.Sleep(time.Second)
+}
 
-// 			// Expect one RESPONSE message.
-// 			conn.EXPECT().
-// 				ReadFrom(gomock.AssignableToTypeOf([]byte{})).
-// 				DoAndReturn(func(b []byte) (int, net.Addr, error) {
-// 					return copy(b, newResponsePayload(e)), new(net.UDPAddr), nil
-// 				}).
-// 				AnyTimes()
+func TestFindPeers(t *testing.T) {
+	t.Parallel()
 
-// 			return conn, nil
-// 		},
-// 	}
+	const (
+		N  = 2
+		ns = "test-findpeers"
+	)
 
-// 	s, err := survey.New(h, new(net.UDPAddr), survey.WithTransport(mockTransport))
-// 	require.NoError(t, err, "should open packet connections")
-// 	require.NotNil(t, s, "should return surveyor")
-// 	defer s.Close()
+	var (
+		err  error
+		addr = &net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 8822,
+		}
+	)
 
-// 	t.Run("ShouldAdvertise", func(t *testing.T) {
-// 		ttl, err := s.Advertise(ctx, testNs, discovery.TTL(advertiseTTL))
-// 		require.NoError(t, err, "should advertise successfully")
-// 		require.Equal(t, advertiseTTL, ttl, "should return advertised TTL")
-// 	})
+	tt := newTestTable(t, N)
+	defer closeTestTable(tt)
 
-// 	t.Run("ShouldFindPeer", func(t *testing.T) {
-// 		finder, err := s.FindPeers(ctx, testNs)
-// 		require.NoError(t, err, "should issue request packet")
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-// 		select {
-// 		case <-time.After(time.Second):
-// 			t.Error("should receive response")
-// 		case info := <-finder:
-// 			// NOTE: we advertised h's record to avoid creating a separate host
-// 			require.Equal(t, info, *host.InfoFromHost(h))
-// 		}
-// 	})
+	conn := mock_net.NewMockPacketConn(ctrl)
 
-// 	t.Run("Close", func(t *testing.T) {
-// 		require.NoError(t, s.Close(), "should close without error")
+	request, err := loadRequest(tt[0].c, tt[0].h, ns, 255)
+	require.NoError(t, err)
 
-// 		ttl, err := s.Advertise(ctx, testNs)
-// 		require.ErrorIs(t, err, survey.ErrClosed)
-// 		require.Zero(t, ttl)
+	response, err := loadResponse(tt[1].c, tt[1].h, ns)
+	require.NoError(t, err)
 
-// 		ch, err := s.FindPeers(ctx, testNs)
-// 		require.ErrorIs(t, err, survey.ErrClosed)
-// 		require.Nil(t, ch)
-// 	})
-// }
+	conn.EXPECT().LocalAddr().Return(addr).Times(1)
+	conn.EXPECT().WriteTo(request, addr).Times(1)
+	conn.EXPECT().ReadFrom(gomock.Any()).DoAndReturn(readIncomingRequest(response, addr)).MinTimes(1)
+	conn.EXPECT().Close().Times(1)
 
-// func newTestHost() host.Host {
-// 	h, err := libp2p.New(
-// 		libp2p.NoListenAddrs,
-// 		libp2p.NoTransports,
-// 		libp2p.Transport(inproc.New()),
-// 		libp2p.ListenAddrStrings("/inproc/~"))
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	surveyor := survey.New(tt[0].h, conn)
+	defer surveyor.Close()
 
-// 	return h
-// }
+	peers, err := surveyor.FindPeers(context.Background(), ns, discovery.Limit(1))
+	require.NoError(t, err)
 
-// func newResponsePayload(e *record.Envelope) []byte {
-// 	b, err := e.Marshal()
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	peersAmount := 0
+	for info := range peers {
+		require.EqualValues(t, tt[1].h.Addrs(), info.Addrs)
+		require.EqualValues(t, tt[1].h.ID(), info.ID)
 
-// 	m, s, err := capnp.NewMessage(capnp.SingleSegment(nil))
-// 	if err != nil {
-// 		panic(err)
-// 	}
+		peersAmount++
+	}
+	require.Equal(t, 1, peersAmount)
+}
 
-// 	p, err := boot.NewRootPacket(s)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+func newTestTable(t *testing.T, N int) []test {
+	var (
+		tt  = make([]test, N)
+		err error
+	)
 
-// 	if err = p.SetNamespace(testNs); err != nil {
-// 		panic(err)
-// 	}
+	for i := 0; i < N; i++ {
+		tt[i].h, err = newTestHost()
+		require.NoError(t, err)
 
-// 	if err = p.SetResponse(b); err != nil {
-// 		panic(err)
-// 	}
+		rec, err := waitReady(tt[i].h)
+		require.NoError(t, err)
 
-// 	if b, err = m.MarshalPacked(); err != nil {
-// 		panic(err)
-// 	}
+		tt[i].c, err = socket.NewRecordCache(2)
+		require.NoError(t, err)
 
-// 	return b
-// }
+		tt[i].c.Reset(rec)
+	}
+	return tt
+}
+
+func closeTestTable(tt []test) {
+	for _, t := range tt {
+		t.h.Close()
+	}
+}
+
+func newTestHost() (host.Host, error) {
+	h, err := libp2p.New(
+		libp2p.NoListenAddrs,
+		libp2p.NoTransports,
+		libp2p.Transport(inproc.New()),
+		libp2p.ListenAddrStrings("/inproc/~"))
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func waitReady(h host.Host) (*record.Envelope, error) {
+	sub, err := h.EventBus().Subscribe(new(event.EvtLocalAddressesUpdated))
+	if err != nil {
+		return nil, err
+	}
+	defer sub.Close()
+
+	v := <-sub.Out()
+	return v.(event.EvtLocalAddressesUpdated).SignedPeerRecord, nil
+}
+
+func readIncomingRequest(request []byte, from net.Addr) func([]byte) (int, net.Addr, error) {
+	return func(b []byte) (n int, addr net.Addr, err error) {
+		err = nil
+		n = copy(b, request)
+		addr = from
+		return
+	}
+}
+
+func loadRequest(cache *socket.RecordCache, h host.Host, ns string, distance uint8) ([]byte, error) {
+	request, err := cache.LoadSurveyRequest(sealer(h), h.ID(), ns, distance)
+	if err != nil {
+		return nil, err
+	}
+	return request.Marshal()
+}
+
+func loadResponse(cache *socket.RecordCache, h host.Host, ns string) ([]byte, error) {
+	response, err := cache.LoadResponse(sealer(h), ns)
+	if err != nil {
+		return nil, err
+	}
+	return response.Marshal()
+}
+
+func sealer(h host.Host) socket.Sealer {
+	return func(r record.Record) (*record.Envelope, error) {
+		return record.Seal(r, h.Peerstore().PrivKey(h.ID()))
+	}
+}

--- a/pkg/boot/survey/survey_test.go
+++ b/pkg/boot/survey/survey_test.go
@@ -22,7 +22,7 @@ import (
 
 type test struct {
 	h host.Host
-	c *socket.RecordCache
+	c *socket.RequestResponseCache
 	t *tracker.HostTracker
 }
 
@@ -151,7 +151,7 @@ func newTestTable(t *testing.T, N int) []test {
 		_, err = waitReady(tt[i].h)
 		require.NoError(t, err)
 
-		tt[i].c, err = socket.NewRecordCache(2)
+		tt[i].c, err = socket.NewCache(2)
 		require.NoError(t, err)
 
 		tt[i].t = tracker.New(tt[i].h)

--- a/pkg/util/host/tracker.go
+++ b/pkg/util/host/tracker.go
@@ -1,0 +1,104 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/libp2p/go-libp2p-core/event"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/record"
+)
+
+var ErrClosed = errors.New("closed")
+
+type RecordProvider interface {
+	Record() *peer.PeerRecord
+}
+
+type HostTracker struct {
+	host host.Host
+
+	envelope atomic.Value
+
+	once sync.Once
+	sub  event.Subscription
+
+	callbacks []Callback
+}
+
+type Callback func()
+
+func NewHostTracker(h host.Host, callback ...Callback) *HostTracker {
+	return &HostTracker{host: h, callbacks: callback}
+}
+
+func (h *HostTracker) Ensure(ctx context.Context) (err error) {
+	h.once.Do(func() {
+		if len(h.host.Addrs()) == 0 {
+			err = errors.New("host not accepting connections")
+			return
+		}
+
+		h.sub, err = h.host.EventBus().Subscribe(new(event.EvtLocalAddressesUpdated))
+		if err != nil {
+			return
+		}
+
+		// Ensure a sync operation is run before continuing the call
+		// to Advertise, as this may otherwise cause a panic.
+		//
+		// The host may have unregistered its addresses concurrently
+		// with the call to Subscribe, so we provide a cancellation
+		// mechanism via the context.  Note that if the first call to
+		// ensureTrackHostAddr fails, subsequent calls will also fail.
+		select {
+		case v, ok := <-h.sub.Out():
+			if !ok {
+				err = fmt.Errorf("host %w", ErrClosed)
+				return
+			}
+
+			evt := v.(event.EvtLocalAddressesUpdated)
+			h.envelope.Store(evt.SignedPeerRecord)
+			h.callCallbacks()
+
+		case <-ctx.Done():
+			h.sub.Close()
+			err = ctx.Err()
+			return
+		}
+
+		go func() {
+			for v := range h.sub.Out() {
+				evt := v.(event.EvtLocalAddressesUpdated)
+				h.envelope.Store(evt.SignedPeerRecord)
+				h.callCallbacks()
+			}
+		}()
+
+	})
+
+	return
+}
+
+func (h HostTracker) callCallbacks() {
+	for _, c := range h.callbacks {
+		go c()
+	}
+}
+
+func (h HostTracker) Close() error {
+	return h.sub.Close()
+}
+
+func (h HostTracker) Record() *peer.PeerRecord {
+	var rec peer.PeerRecord
+
+	envelope := h.envelope.Load().(*record.Envelope)
+	envelope.TypedRecord(&rec)
+	return &rec
+}

--- a/pkg/util/tracker/tracker.go
+++ b/pkg/util/tracker/tracker.go
@@ -27,7 +27,7 @@ type HostAddrTracker struct {
 	callbacks []Callback
 }
 
-type Callback func()
+type Callback func(*peer.PeerRecord)
 
 func New(h host.Host, callback ...Callback) *HostAddrTracker {
 	return &HostAddrTracker{host: h, callbacks: callback}
@@ -108,8 +108,9 @@ func (h HostAddrTracker) callCallbacks() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	rec := h.Record()
 	for _, c := range h.callbacks {
-		go c()
+		go c(rec)
 	}
 }
 

--- a/pkg/util/tracker/tracker.go
+++ b/pkg/util/tracker/tracker.go
@@ -15,7 +15,7 @@ import (
 
 var ErrClosed = errors.New("closed")
 
-type HostTracker struct {
+type HostAddrTracker struct {
 	host host.Host
 
 	envelope atomic.Value
@@ -29,11 +29,11 @@ type HostTracker struct {
 
 type Callback func()
 
-func New(h host.Host, callback ...Callback) *HostTracker {
-	return &HostTracker{host: h, callbacks: callback}
+func New(h host.Host, callback ...Callback) *HostAddrTracker {
+	return &HostAddrTracker{host: h, callbacks: callback}
 }
 
-func (h *HostTracker) Ensure(ctx context.Context) (err error) {
+func (h *HostAddrTracker) Ensure(ctx context.Context) (err error) {
 	h.once.Do(func() {
 		if len(h.host.Addrs()) == 0 {
 			err = errors.New("host not accepting connections")
@@ -82,11 +82,11 @@ func (h *HostTracker) Ensure(ctx context.Context) (err error) {
 	return
 }
 
-func (h HostTracker) Close() error {
+func (h HostAddrTracker) Close() error {
 	return h.sub.Close()
 }
 
-func (h HostTracker) Record() *peer.PeerRecord {
+func (h HostAddrTracker) Record() *peer.PeerRecord {
 	var rec peer.PeerRecord
 
 	envelope := h.envelope.Load().(*record.Envelope)
@@ -94,14 +94,14 @@ func (h HostTracker) Record() *peer.PeerRecord {
 	return &rec
 }
 
-func (h HostTracker) AddCallback(c Callback) {
+func (h HostAddrTracker) AddCallback(c Callback) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	h.callbacks = append(h.callbacks, c)
 }
 
-func (h HostTracker) callCallbacks() {
+func (h HostAddrTracker) callCallbacks() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 

--- a/pkg/util/tracker/tracker.go
+++ b/pkg/util/tracker/tracker.go
@@ -83,7 +83,10 @@ func (h *HostAddrTracker) Ensure(ctx context.Context) (err error) {
 }
 
 func (h HostAddrTracker) Close() error {
-	return h.sub.Close()
+	if h.sub != nil {
+		return h.sub.Close()
+	}
+	return nil
 }
 
 func (h HostAddrTracker) Record() *peer.PeerRecord {

--- a/pkg/util/tracker/tracker_test.go
+++ b/pkg/util/tracker/tracker_test.go
@@ -1,0 +1,136 @@
+package tracker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/event"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/record"
+	inproc "github.com/lthibault/go-libp2p-inproc-transport"
+	"github.com/stretchr/testify/require"
+	"github.com/wetware/casm/pkg/util/tracker"
+)
+
+func TestEnsure(t *testing.T) {
+	t.Parallel()
+
+	h, err := newTestHost()
+	require.NoError(t, err)
+
+	addrs := make(chan *peer.PeerRecord, 0)
+	callback := func(rec *peer.PeerRecord) {
+		addrs <- rec
+	}
+
+	tr := tracker.New(h, callback)
+	waitReady(h)
+	// until Ensure is not called, no record is tracked
+	require.Nil(t, tr.Record())
+
+	err = tr.Ensure(context.Background())
+	require.NoError(t, err)
+
+	// right after calling Ensure a record should be available
+	require.NotNil(t, tr.Record())
+}
+
+func TestClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h, err := newTestHost()
+	require.NoError(t, err)
+
+	tr := tracker.New(h)
+
+	err = tr.Ensure(ctx)
+	require.NoError(t, err)
+	rec := tr.Record()
+	require.NotNil(t, rec)
+
+	tr.Close()
+	// after closing the record must be same
+	require.Equal(t, rec, tr.Record())
+}
+
+func TestCallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("init callback", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		h, err := newTestHost()
+		require.NoError(t, err)
+
+		records := make(chan *peer.PeerRecord, 0)
+		callback := func(rec *peer.PeerRecord) {
+			records <- rec
+		}
+
+		tr := tracker.New(h, callback)
+
+		err = tr.Ensure(ctx)
+		require.NoError(t, err)
+		defer tr.Close()
+
+		rec := <-records
+		println(h, rec)
+		require.Equal(t, h.ID(), rec.PeerID)
+	})
+
+	t.Run("added callback after init", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		h, err := newTestHost()
+		require.NoError(t, err)
+
+		records := make(chan *peer.PeerRecord, 0)
+		callback := func(rec *peer.PeerRecord) {
+			records <- rec
+		}
+
+		tr := tracker.New(h)
+		tr.AddCallback(callback)
+
+		err = tr.Ensure(ctx)
+		require.NoError(t, err)
+
+		rec := <-records
+		require.Equal(t, h.ID(), rec.PeerID)
+	})
+}
+
+func newTestHost() (host.Host, error) {
+	h, err := libp2p.New(
+		libp2p.NoListenAddrs,
+		libp2p.NoTransports,
+		libp2p.Transport(inproc.New()),
+		libp2p.ListenAddrStrings("/inproc/~"))
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func waitReady(h host.Host) (*record.Envelope, error) {
+	sub, err := h.EventBus().Subscribe(new(event.EvtLocalAddressesUpdated))
+	if err != nil {
+		return nil, err
+	}
+	defer sub.Close()
+
+	v := <-sub.Out()
+	return v.(event.EvtLocalAddressesUpdated).SignedPeerRecord, nil
+}


### PR DESCRIPTION
Refactored boot package

Summary:
- Replaced `panic` calls for `errors` 
- Renamed some functions for readability
- Extracted `Host` address tracking logic to a separate package `tracker`
- Fixed data race condition between `crawler`/`surveyor` and `socket`

Additionally:

- Added tests for `surveyor` 