### PR TITLE
fix silence EOF error on Socket

### DIFF
--- a/pkg/boot/socket/option.go
+++ b/pkg/boot/socket/option.go
@@ -38,13 +38,15 @@ func WithValidator(v RecordValidator) Option {
 func WithErrHandler(h func(*Socket, error)) Option {
 	if h == nil {
 		h = func(sock *Socket, err error) {
+			select {
+			case <-sock.Done(): // if sock is closed, log as debug
+				sock.Log().Debug(err)
+			default:
+			}
+
 			switch e := err.(type) {
 			case net.Error:
-				select {
-				case <-sock.Done():
-				default:
-					sock.Log().Error(err)
-				}
+				sock.Log().Error(err)
 
 			case ProtocolError:
 				sock.Log().With(e).Debug(e.Message)

--- a/pkg/boot/socket/option.go
+++ b/pkg/boot/socket/option.go
@@ -41,6 +41,7 @@ func WithErrHandler(h func(*Socket, error)) Option {
 			select {
 			case <-sock.Done(): // if sock is closed, log as debug
 				sock.Log().Debug(err)
+				return
 			default:
 			}
 


### PR DESCRIPTION
Error on `Socket` is logged as debug if the socket is closed. The error is documented in #37 