### PR TITLE
Add STM package.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.0.0-alpha.5
 	github.com/coreos/go-semver v0.3.0
 	github.com/golang/mock v1.6.0
+	github.com/hashicorp/go-memdb v1.3.3
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-datastore v0.5.1
 	github.com/jpillora/backoff v1.0.0
@@ -57,6 +58,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huin/goupnp v1.0.2 // indirect
 	github.com/ipfs/go-cid v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
+github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-memdb v1.3.3 h1:oGfEWrFuxtIUF3W2q/Jzt6G85TrMk9ey6XfYLvVe1Wo=
+github.com/hashicorp/go-memdb v1.3.3/go.mod h1:uBTr1oQbtuMgd1SSGoR8YV27eT3sBHbYiNm53bMpgSg=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
@@ -333,6 +337,7 @@ github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=

--- a/pkg/stm/doc.go
+++ b/pkg/stm/doc.go
@@ -1,0 +1,10 @@
+/*
+Package stm implements software-transactional memory (STM).
+
+TODO(documentation):
+
+  - Overview of STM and MVCC
+  - Invariants (no mutation, etc.)
+  - Security model (OCAP and TableRef)
+*/
+package stm

--- a/pkg/stm/stm.go
+++ b/pkg/stm/stm.go
@@ -1,0 +1,83 @@
+package stm
+
+import (
+	"github.com/hashicorp/go-memdb"
+)
+
+// TableRef is a token that allows the holder to designate a table
+// in the Scheduler.   It is effectively an object capability that
+// confers access to a given table.  The table's name is kept in a
+// private field to prevent unauthorized code from designating the
+// table (i.e. unauthorized users have no way to pass in a table).
+type TableRef struct {
+	name string
+}
+
+// Factory populates a memdb schema and generates secure TableRefs.
+type Factory struct {
+	schema *memdb.DBSchema
+}
+
+// Register a table schema for the scheduler.  The returned TableRef
+// is required for operations against the table defined by t.  If a
+// schema already exists with the supplied name, Register will panic.
+func (f *Factory) Register(name string, t *memdb.TableSchema) TableRef {
+	// initialize the db schema?
+	if f.schema == nil {
+		f.schema = &memdb.DBSchema{
+			Tables: make(map[string]*memdb.TableSchema, 1),
+		}
+	}
+
+	if _, exists := f.schema.Tables[name]; exists {
+		panic("schema collision")
+	}
+
+	// create a cryptographically-secure key for the table.
+	f.schema.Tables[name] = t
+
+	// return a TableRef, which can be used to designate the table.
+	return TableRef{name: name}
+}
+
+// NewScheduler returns a Scheduler, initialized with the tables
+// that have have been registered to the Factory before the call.
+// Successive calls to NewScheduler produce independent instances
+// of Scheduler that do not share any additional state beyond the
+// underlying schema and TableRefs.
+func (f *Factory) NewScheduler() (s Scheduler, err error) {
+	s.db, err = memdb.NewMemDB(f.schema)
+	return
+}
+
+// Scheduler provides transactions that guarantee the ACID properties
+// of Atomicity, Consistency and Isolation.
+//
+// Objects managed by the scheduler are updated through MVCC.  These
+// objects are not copied, and MUST NOT be modified in-place after they
+// have been inserted. For the avoidance of doubt, said objects MUST NOT
+// be updated after they have been deleted from the scheduler since they
+// may still be present in snapshots held by other goroutines.
+type Scheduler struct {
+	db *memdb.MemDB
+}
+
+// Txn is used to start a new transaction in either read or write mode.
+// There can only be a single concurrent writer, but any number of readers.
+func (s Scheduler) Txn(write bool) Txn {
+	return Txn{
+		txn: s.db.Txn(write),
+	}
+}
+
+// Snapshot is used to capture a point-in-time snapshot  of the database that
+// will not be affected by any write operations to the existing Scheduler.
+//
+// If the Scheduler is storing reference-based values (pointers, maps, slices,
+// etc.), the Snapshot will not deep copy those values. Therefore, it is still
+// unsafe to modify any inserted values in either DB.
+func (s Scheduler) Snapshot() Scheduler {
+	return Scheduler{
+		db: s.db.Snapshot(),
+	}
+}

--- a/pkg/stm/stm_test.go
+++ b/pkg/stm/stm_test.go
@@ -1,0 +1,96 @@
+package stm_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wetware/casm/pkg/stm"
+)
+
+func TestSTM(t *testing.T) {
+	t.Parallel()
+
+	var (
+		f       stm.Factory
+		s, snap stm.Scheduler
+		ref     stm.TableRef
+	)
+
+	t.Run("Factory", func(t *testing.T) {
+		ref = f.Register("test", &memdb.TableSchema{
+			Name: "test",
+			Indexes: map[string]*memdb.IndexSchema{
+				"id": {
+					Name:    "id",
+					Unique:  true,
+					Indexer: &memdb.BoolFieldIndex{Field: "Test"},
+				},
+			},
+		})
+		assert.NotZero(t, ref, "table ref should be populated")
+
+		assert.Panics(t, func() { _ = f.Register("test", nil) },
+			"duplicate table name should cause panic")
+
+		var err error
+		s, err = f.NewScheduler()
+		require.NoError(t, err, "schema should be valid")
+		assert.NotZero(t, s, "should allocate scheduler")
+
+		// We take a snapshot of the initial (empty) state of the
+		// scheduler. After committing our writes, we will verify
+		// that it has not mutated.
+		snap = s.Snapshot()
+	})
+
+	t.Run("Insert", func(t *testing.T) {
+		tx := s.Txn(true)
+		defer tx.Commit()
+
+		err := tx.Insert(ref, struct{ Test bool }{Test: true})
+		assert.NoError(t, err, "should insert 'true' case")
+
+		err = tx.Insert(ref, struct{ Test bool }{})
+		assert.NoError(t, err, "should insert 'false' case")
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		t.Helper()
+
+		t.Run("Get", func(t *testing.T) {
+			t.Parallel()
+
+			tx := s.Txn(false)
+			defer tx.Commit()
+
+			it, err := tx.Get(ref, "id", true)
+			require.NoError(t, err, "query 'get' should succeed")
+
+			var results []bool
+			for v := it.Next(); v != nil; v = it.Next() {
+				t.Logf("got:\t%v", v)
+				results = append(results, v.(struct{ Test bool }).Test)
+			}
+
+			assert.Contains(t, results, true)
+			assert.NotContains(t, results, false)
+		})
+	})
+
+	t.Run("Snapshot", func(t *testing.T) {
+		t.Parallel()
+
+		// Now let's check that the snaphsot was not mutated.
+		tx := snap.Txn(false)
+
+		it, err := tx.Get(ref, "id", true)
+		require.NoError(t, err, "query 'get' should succeed")
+		assert.Nil(t, it.Next(), "iterator should be exhausted")
+
+		it, err = tx.Get(ref, "id", false)
+		require.NoError(t, err, "query 'get' should succeed")
+		assert.Nil(t, it.Next(), "iterator should be exhausted")
+	})
+}

--- a/pkg/stm/txn.go
+++ b/pkg/stm/txn.go
@@ -1,0 +1,229 @@
+package stm
+
+import "github.com/hashicorp/go-memdb"
+
+// Txn is a transaction against a Scheduler instance.
+// This can be a read or write transaction.
+type Txn struct {
+	txn *memdb.Txn
+}
+
+// TrackChanges enables change tracking for the transaction. If called at any
+// point before commit, subsequent mutations will be recorded and can be
+// retrieved using ChangeSet. Once this has been called on a transaction it
+// can't be unset. As with other Txn methods it's not safe to call this from a
+// different goroutine than the one making mutations or committing the
+// transaction.
+func (t Txn) TrackChanges() {
+	t.txn.TrackChanges()
+}
+
+// Abort is used to cancel this transaction.
+// This is a noop for read transactions,
+// already aborted or commited transactions.
+func (t Txn) Abort() {
+	t.txn.Abort()
+}
+
+// Commit is used to finalize this transaction.
+// This is a noop for read transactions,
+// already aborted or committed transactions.
+func (t Txn) Commit() {
+	t.txn.Commit()
+}
+
+// Insert is used to add or update an object into the given table.
+//
+// When updating an object, the obj provided should be a copy rather
+// than a value updated in-place. Modifying values in-place that are already
+// inserted into MemDB is not supported behavior.
+func (t Txn) Insert(table TableRef, v any) error {
+	return t.txn.Insert(table.name, v)
+}
+
+// Delete is used to delete a single object from the given table.
+// This object must already exist in the table.
+func (t Txn) Delete(table TableRef, v any) error {
+	return t.txn.Delete(table.name, v)
+}
+
+// DeletePrefix is used to delete an entire subtree based on a prefix.
+// The given index must be a prefix index, and will be used to perform
+// a scan and enumerate the set of objects to delete.  These will be
+// removed from all other indexes, and then a special prefix operation
+// will delete the objects from the given index in an efficient subtree
+// delete operation.
+//
+// This is useful when you have a very large number of objects indexed
+// by the given index, along with a much smaller number of entries in
+// the other indexes for those objects.
+func (t Txn) DeletePrefix(table TableRef, prefix_index string, prefix string) (bool, error) {
+	return t.txn.DeletePrefix(table.name, prefix_index, prefix)
+}
+
+// DeleteAll is used to delete all the objects in a given table
+// matching the constraints on the index
+func (t Txn) DeleteAll(table TableRef, index string, args ...any) (int, error) {
+	return t.txn.DeleteAll(table.name, index, args...)
+}
+
+// FirstWatch is used to return the first matching object for
+// the given constraints on the index along with the watch channel.
+//
+// Note that all values read in the transaction form a consistent snapshot
+// from the time when the transaction was created.
+//
+// The watch channel is closed when a subsequent write transaction
+// has updated the result of the query. Since each read transaction
+// operates on an isolated snapshot, a new read transaction must be
+// started to observe the changes that have been made.
+//
+// If the value of index ends with "_prefix", FirstWatch will perform a prefix
+// match instead of full match on the index. The registered indexer must implement
+// PrefixIndexer, otherwise an error is returned.
+func (t Txn) FirstWatch(table TableRef, index string, args ...any) (<-chan struct{}, any, error) {
+	return t.txn.FirstWatch(table.name, index, args...)
+}
+
+// LastWatch is used to return the last matching object for
+// the given constraints on the index along with the watch channel.
+//
+// Note that all values read in the transaction form a consistent snapshot
+// from the time when the transaction was created.
+//
+// The watch channel is closed when a subsequent write transaction
+// has updated the result of the query. Since each read transaction
+// operates on an isolated snapshot, a new read transaction must be
+// started to observe the changes that have been made.
+//
+// If the value of index ends with "_prefix", LastWatch will perform a prefix
+// match instead of full match on the index. The registered indexer must implement
+// PrefixIndexer, otherwise an error is returned.
+func (t Txn) LastWatch(table TableRef, index string, args ...any) (<-chan struct{}, any, error) {
+	return t.txn.LastWatch(table.name, index, args...)
+}
+
+// First is used to return the first matching object for
+// the given constraints on the index.
+//
+// Note that all values read in the transaction form a consistent snapshot
+// from the time when the transaction was created.
+func (t Txn) First(table TableRef, index string, args ...any) (any, error) {
+	return t.txn.First(table.name, index, args...)
+}
+
+// Last is used to return the last matching object for
+// the given constraints on the index.
+//
+// Note that all values read in the transaction form a consistent snapshot
+// from the time when the transaction was created.
+func (t Txn) Last(table TableRef, index string, args ...any) (any, error) {
+	return t.txn.Last(table.name, index, args...)
+}
+
+// LongestPrefix is used to fetch the longest prefix match for the given
+// constraints on the index. Note that this will not work with the memdb
+// StringFieldIndex because it adds null terminators which prevent the
+// algorithm from correctly finding a match (it will get to right before the
+// null and fail to find a leaf node). This should only be used where the prefix
+// given is capable of matching indexed entries directly, which typically only
+// applies to a custom indexer. See the unit test for an example.
+//
+// Note that all values read in the transaction form a consistent snapshot
+// from the time when the transaction was created.
+func (t Txn) LongestPrefix(table TableRef, index string, args ...any) (any, error) {
+	return t.txn.LongestPrefix(table.name, index, args...)
+}
+
+// Get is used to construct a ResultIterator over all the rows that match the
+// given constraints of an index. The index values must match exactly (this
+// is not a range-based or prefix-based lookup) by default.
+//
+// Prefix lookups: if the named index implements PrefixIndexer, you may perform
+// prefix-based lookups by appending "_prefix" to the index name. In this
+// scenario, the index values given in args are treated as prefix lookups. For
+// example, a StringFieldIndex will match any string with the given value
+// as a prefix: "mem" matches "memdb".
+//
+// See the documentation for ResultIterator to understand the behaviour of the
+// returned ResultIterator.
+func (t Txn) Get(table TableRef, index string, args ...any) (memdb.ResultIterator, error) {
+	return t.txn.Get(table.name, index, args...)
+}
+
+// GetReverse is used to construct a Reverse ResultIterator over all the
+// rows that match the given constraints of an index.
+// The returned ResultIterator's Next() will return the next Previous value.
+//
+// See the documentation on Get for details on arguments.
+//
+// See the documentation for ResultIterator to understand the behaviour of the
+// returned ResultIterator.
+func (t Txn) GetReverse(table TableRef, index string, args ...any) (memdb.ResultIterator, error) {
+	return t.txn.GetReverse(table.name, index, args...)
+}
+
+// LowerBound is used to construct a ResultIterator over all the the range of
+// rows that have an index value greater than or equal to the provide args.
+// Calling this then iterating until the rows are larger than required allows
+// range scans within an index. It is not possible to watch the resulting
+// iterator since the radix tree doesn't efficiently allow watching on lower
+// bound changes. The WatchCh returned will be nill and so will block forever.
+//
+// If the value of index ends with "_prefix", LowerBound will perform a prefix match instead of
+// a full match on the index. The registered index must implement PrefixIndexer,
+// otherwise an error is returned.
+//
+// See the documentation for ResultIterator to understand the behaviour of the
+// returned ResultIterator.
+func (t Txn) LowerBound(table TableRef, index string, args ...any) (memdb.ResultIterator, error) {
+	return t.txn.LowerBound(table.name, index, args...)
+}
+
+// ReverseLowerBound is used to construct a Reverse ResultIterator over all the
+// the range of rows that have an index value less than or equal to the
+// provide args.  Calling this then iterating until the rows are lower than
+// required allows range scans within an index. It is not possible to watch the
+// resulting iterator since the radix tree doesn't efficiently allow watching
+// on lower bound changes. The WatchCh returned will be nill and so will block
+// forever.
+//
+// See the documentation for ResultIterator to understand the behaviour of the
+// returned ResultIterator.
+func (t Txn) ReverseLowerBound(table TableRef, index string, args ...any) (memdb.ResultIterator, error) {
+	return t.txn.ReverseLowerBound(table.name, index, args...)
+}
+
+// Changes returns the set of object changes that have been made in the
+// transaction so far. If change tracking is not enabled it wil always return
+// nil. It can be called before or after Commit. If it is before Commit it will
+// return all changes made so far which may not be the same as the final
+// Changes. After abort it will always return nil. As with other Txn methods
+// it's not safe to call this from a different goroutine than the one making
+// mutations or committing the transaction. Mutations will appear in the order
+// they were performed in the transaction but multiple operations to the same
+// object will be collapsed so only the effective overall change to that object
+// is present. If transaction operations are dependent (e.g. copy object X to Y
+// then delete X) this might mean the set of mutations is incomplete to verify
+// history, but it is complete in that the net effect is preserved (Y got a new
+// value, X got removed).
+func (t Txn) Changes() memdb.Changes {
+	return t.txn.Changes()
+}
+
+// Defer is used to push a new arbitrary function onto a stack which
+// gets called when a transaction is committed and finished. Deferred
+// functions are called in LIFO order, and only invoked at the end of
+// write transactions.
+func (t Txn) Defer(fn func()) {
+	t.txn.Defer(fn)
+}
+
+// Snapshot creates a snapshot of the current state of the transaction.
+// Returns a new read-only transaction or nil if the transaction is
+// already aborted or committed.
+func (t Txn) Snapshot() Txn {
+	return Txn{
+		txn: t.txn.Snapshot(),
+	}
+}


### PR DESCRIPTION
This is a pre-flight PR for https://github.com/wetware/ww/issues/36.  It ports the STM package from Wetware to CASM, since it will be needed for the indexed routing-table implementation.  This PR is provided separately in an effort to keep changes small.