### PR TITLE
Fix infinite loop stream closed

### DIFF
--- a/pkg/util/stream/stream.go
+++ b/pkg/util/stream/stream.go
@@ -39,6 +39,11 @@ func (s *Stream[T]) Call(ctx context.Context, args func(T) error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if ctx.Err() != nil {
+		s.close()
+		return
+	}
+
 	if !s.closing {
 		// append to inflight queue
 		s.inflight.Put(s.call(ctx, s.method, args))


### PR DESCRIPTION
This PR fixes a bug caused by capnp. Currently, enter an infinite loop were the stream does not close if an outbounding RPC call is open when the connection drops