### PR TITLE
Fix protoutil.SemVer to be standards-compliant.

### DIFF
--- a/pkg/util/proto/match.go
+++ b/pkg/util/proto/match.go
@@ -65,6 +65,12 @@ func Suffix(suffix protocol.ID) (f MatchFunc) {
 	})
 }
 
+// SemVer returns a function that compares the protocol ID with the
+// supplied semantic version string.  It returns true iff the major
+// version numbers are identical.
+//
+// SemVer is compliant with the Semantic Versioning 2.0.0 spec.
+// https://semver.org/
 func SemVer(version string) MatchFunc {
 	v := semver.New(clean(version))
 
@@ -76,7 +82,7 @@ func SemVer(version string) MatchFunc {
 			return s, false
 		}
 
-		return tail, v.Major == sv.Major && v.Minor >= sv.Minor
+		return tail, v.Major == sv.Major
 	})
 }
 

--- a/pkg/util/proto/match_test.go
+++ b/pkg/util/proto/match_test.go
@@ -1,7 +1,10 @@
-package protoutil
+package protoutil_test
 
 import (
 	"testing"
+
+	"github.com/libp2p/go-libp2p/core/protocol"
+	protoutil "github.com/wetware/casm/pkg/util/proto"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -10,98 +13,157 @@ func TestMatchers(t *testing.T) {
 	t.Parallel()
 	t.Helper()
 
-	for _, tt := range []struct {
-		name          string
-		matcher       MatchFunc
-		input         string
-		expectNoMatch bool
-	}{
+	for _, tt := range []matcherTest{
 		{
 			name:    "Exactly/match",
-			matcher: Exactly("foo"),
+			matcher: protoutil.Exactly("foo"),
 			input:   "/foo/bar/",
 		},
 		{
 			name:          "Exactly/reject",
-			matcher:       Exactly("bar"),
+			matcher:       protoutil.Exactly("bar"),
 			input:         "/foo/bar/",
 			expectNoMatch: true,
 		},
 		{
 			name:    "Prefix/match",
-			matcher: Prefix("/foo/bar/"),
+			matcher: protoutil.Prefix("/foo/bar/"),
 			input:   "/foo/bar/baz/qux",
 		},
 		{
 			name:          "Prefix/reject",
-			matcher:       Prefix("/foo/bar/"),
+			matcher:       protoutil.Prefix("/foo/bar/"),
 			input:         "/bar/foo/baz/qux/",
 			expectNoMatch: true,
 		},
 		{
 			name:    "Suffix/Match",
-			matcher: Suffix("/baz/qux"),
+			matcher: protoutil.Suffix("/baz/qux"),
 			input:   "/foo/bar/baz/qux",
 		},
 		{
 			name:          "Suffix/reject",
-			matcher:       Suffix("/baz/qux/"),
+			matcher:       protoutil.Suffix("/baz/qux/"),
 			input:         "/foo/bar/qux/baz/",
 			expectNoMatch: true,
 		},
 		{
-			name:    "SemVer/match",
-			matcher: SemVer("1.1.0-beta.1"),
-			input:   "/1.1.5/",
-		},
-		{
-			name:    "SemVer/match/minor",
-			matcher: SemVer("1.1.0-beta.1"),
-			input:   "/1.0.0/",
-		},
-		{
-			name:          "SemVer/reject",
-			matcher:       SemVer("1.1.0-beta.1"),
-			input:         "/foobar/2.1.0/",
-			expectNoMatch: true,
-		},
-		{
-			name:          "SemVer/reject/minor",
-			matcher:       SemVer("1.1.0-beta.1"),
-			input:         "/1.2.1/",
-			expectNoMatch: true,
-		},
-		{
-			name:          "SemVer/reject/malformed",
-			matcher:       SemVer("1.1.0-beta.1"),
-			input:         "/not a semver string/",
-			expectNoMatch: true,
-		},
-		{
 			name: "MatchComplex",
-			matcher: Match(
-				Prefix("ww"),
-				SemVer("1.5.1"),
-				Exactly("ns"),
-				Exactly("rpc")),
+			matcher: protoutil.Match(
+				protoutil.Prefix("ww"),
+				protoutil.SemVer("1.5.1"),
+				protoutil.Exactly("ns"),
+				protoutil.Exactly("rpc")),
 			input: "/ww/1.0.0/ns/rpc/",
 		},
 		{
 			name: "Chain",
-			matcher: Match(
-				Prefix("ww"),
-				SemVer("0.0.0")).Then(Exactly("ns")),
+			matcher: protoutil.Match(
+				protoutil.Prefix("ww"),
+				protoutil.SemVer("0.0.0")).
+				Then(protoutil.Exactly("ns")),
 			input: "/ww/0.0.0/ns",
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			if remainder, match := tt.matcher(tt.input); tt.expectNoMatch {
-				assert.False(t, match,
-					"should not match '%s' (remainder: %s)", tt.input, remainder)
-			} else {
-				assert.True(t, match,
-					"should match '%s' (remainder: %s)", tt.input, remainder)
-			}
-		})
+		tt.Run(t)
 	}
+}
+
+func TestSemVer(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	t.Run("Match", func(t *testing.T) {
+		t.Helper()
+
+		for _, tt := range []matcherTest{
+			{
+				name:    "Identical",
+				matcher: protoutil.SemVer("1.0.0"),
+				input:   "/1.0.0/",
+			},
+			{
+				name:    "MinorVersion/Higher",
+				matcher: protoutil.SemVer("1.0.0"),
+				input:   "/1.2.0/",
+			},
+			{
+				name:    "MinorVersion/Lower",
+				matcher: protoutil.SemVer("1.2.0"),
+				input:   "/1.0.0/",
+			},
+			{
+				name:    "PatchVersion/Higher",
+				matcher: protoutil.SemVer("1.0.0"),
+				input:   "/1.0.3/",
+			},
+			{
+				name:    "PatchVersion/Lower",
+				matcher: protoutil.SemVer("1.0.3"),
+				input:   "/1.0.0/",
+			},
+			{
+				name:    "Pre-Release/Local",
+				matcher: protoutil.SemVer("1.0.0-alpha.1"),
+				input:   "/1.0.0/",
+			},
+			{
+				name:    "Pre-Release/Remote",
+				matcher: protoutil.SemVer("1.0.0"),
+				input:   "/1.0.0-alpha.1/",
+			},
+		} {
+			tt.Run(t)
+		}
+	})
+
+	t.Run("Reject", func(t *testing.T) {
+		t.Helper()
+
+		for _, tt := range []matcherTest{
+			{
+				name:          "MajorVersionsDiffer",
+				matcher:       protoutil.SemVer("1.0.0"),
+				input:         "/2.0.0/",
+				expectNoMatch: true,
+			},
+			{
+				name:          "MajorVersionsDiffer/MinorVersionsMatch",
+				matcher:       protoutil.SemVer("1.1.0"),
+				input:         "/2.1.0/",
+				expectNoMatch: true,
+			},
+			{
+				name:          "MajorVersionsDiffer/PatchVersionsMatch",
+				matcher:       protoutil.SemVer("1.0.1"),
+				input:         "/2.0.1/",
+				expectNoMatch: true,
+			},
+			{
+				name:          "SemVerMalformed",
+				matcher:       protoutil.SemVer("1.0.0"),
+				input:         "/not a semver string/",
+				expectNoMatch: true,
+			},
+		} {
+			tt.Run(t)
+		}
+	})
+}
+
+type matcherTest struct {
+	name          string
+	matcher       protoutil.MatchFunc
+	input         protocol.ID
+	expectNoMatch bool
+}
+
+func (mt matcherTest) Run(t *testing.T) {
+	t.Run(mt.name, func(t *testing.T) {
+		if match := mt.matcher.MatchProto(mt.input); mt.expectNoMatch {
+			assert.False(t, match, "should not match '%s'", mt.input)
+		} else {
+			assert.True(t, match, "should match '%s'", mt.input)
+		}
+	})
 }


### PR DESCRIPTION
Fixes `protoutil.SemVer` to comply to [Semantic Versioning v2.0](https://semver.org).  Also fixes a bug in which matches would succeed for one side of the protocol stream, but not the other.

This patch has the effect of requiring *only* that two streams share the same major version in order to be compatible.