### PR TITLE
Use fixed buffer size in socket subscription channels.

### DIFF
--- a/pkg/boot/socket/socket.go
+++ b/pkg/boot/socket/socket.go
@@ -164,7 +164,7 @@ func (s *Socket) Subscribe(ns string, limit int) (<-chan peer.AddrInfo, func()) 
 
 	var (
 		once sync.Once
-		ch   = make(chan peer.AddrInfo, bufsize(limit))
+		ch   = make(chan peer.AddrInfo, 16) // arbitrary buf size
 	)
 
 	cancel := func() {
@@ -329,14 +329,6 @@ func limiter(limit int, cancel func()) (l *resultLimiter) {
 
 func (l *resultLimiter) Decr() bool {
 	return l != nil && atomic.AddInt32(&l.remaining, -1) == 0
-}
-
-func bufsize(limit int) int {
-	if limit < 0 {
-		return 0
-	}
-
-	return limit
 }
 
 type subscriber struct{ Out chan<- peer.AddrInfo }


### PR DESCRIPTION
This PR is an upstream fix for a bug encountered in Wetware, and for which a workaround was introduced in https://github.com/wetware/ww/commit/61b25e5b15fca3af6a7ef05ce8ba09c8434dca68.

The issue is as follows.  By default, callers of `Socket.Subscribe` will specify a limit of `0` to indicate an unbounded stream of results.  This is translated into a buffer size of `0` on the returned channel.  Consumers of this channel will typically attempt to connect to each peer they receive through this channel.  However, the connection attempt is a blocking operation, which causes any other peers discovered in the meantime to be discarded via

```go
select {
case out <- peer:
default:
}
```

The result is that if the first connection attempt fails, all subsequently-discovered peers have likely been discarded.

The issue was fixed downstream by explicitly setting a generous limit via the `discovery.Limit` option.  However, the default behavior is surprising, and rather difficult to track down.  For this reason, the present PR applies a similar fix upstream.  We arbitrarily chose a fixed channel buffer of `16`, on the assumption that it is generous enough for most applications, while still remaining small.

Additionally, the `discovery.Limit` flag no longer affects the output channel's buffer size.  The reason is that upon further reflection, the previous behavior could easily cause accidental resource exhaustion if an egregiously large limit is specified.  In the current iteration, the limit affects the number of peers to be returned through the channel, independent of any buffering.