### PR TITLE
Suppress debug logs on graceful crawl cancellation.  Refactor Crawler.

### DIFF
--- a/pkg/boot/crawl/crawl.go
+++ b/pkg/boot/crawl/crawl.go
@@ -141,7 +141,7 @@ func (c *Crawler) FindPeers(ctx context.Context, ns string, opt ...discovery.Opt
 				c.sock.Log().
 					WithError(err).
 					WithField("to", &addr).
-					Debug("failed to send request packet")
+					Error("failed to send request packet")
 			}
 
 			return

--- a/pkg/boot/crawl/crawl.go
+++ b/pkg/boot/crawl/crawl.go
@@ -69,7 +69,7 @@ func (c *Crawler) Close() error {
 
 func (c *Crawler) handler() socket.RequestHandler {
 	return func(r socket.Request) error {
-		return c.sock.SendResponse(c.sealer(), c.host, r.From, r.NS)
+		return c.sock.SendResponse(c.sealer, c.host, r.From, r.NS)
 	}
 }
 
@@ -105,16 +105,46 @@ func (c *Crawler) FindPeers(ctx context.Context, ns string, opt ...discovery.Opt
 	go func() {
 		defer cancel()
 
-		var addr net.UDPAddr
+		var (
+			addr net.UDPAddr
+			id   = c.host.ID()
+		)
+
+		// Iterate through the IP range and send request packets.
+		// This is rate-limited by the socket.
 		for c.active(ctx) && iter.Next(&addr) {
-			err := c.sock.SendRequest(ctx, c.sealer(), &addr, c.host.ID(), ns)
-			if err != nil {
+			switch err := c.sock.SendRequest(ctx, c.sealer, &addr, id, ns); err {
+			case nil:
+				// Packet sent.  Keep crawling.
+				c.sock.Log().
+					WithField("to", &addr).
+					Trace("sent request packet")
+				continue
+
+			case context.Canceled:
+				// Graceful abort.  The caller cancels the context when it
+				// has found enough peers.
+				c.sock.Log().
+					Trace("peer discovery finished")
+
+			case context.DeadlineExceeded:
+				// Timeout.  The caller hasn't found enough peers, but has
+				// timed out.  This isn't always an error.  In most cases,
+				// the caller will know what to do.
+				c.sock.Log().
+					WithField("reason", err).
+					Debug("peer discovery aborted")
+
+			default:
+				// Any other error indicates a failure to send the request
+				// packet.  Something definitely went wrong.
 				c.sock.Log().
 					WithError(err).
 					WithField("to", &addr).
 					Debug("failed to send request packet")
-				return
 			}
+
+			return
 		}
 
 		// Wait for response
@@ -138,10 +168,8 @@ func (c *Crawler) active(ctx context.Context) (ok bool) {
 	return
 }
 
-func (c *Crawler) sealer() socket.Sealer {
-	return func(r record.Record) (*record.Envelope, error) {
-		return record.Seal(r, privkey(c.host))
-	}
+func (c *Crawler) sealer(r record.Record) (*record.Envelope, error) {
+	return record.Seal(r, privkey(c.host))
 }
 
 func privkey(h host.Host) crypto.PrivKey {

--- a/pkg/boot/crawl/crawl_test.go
+++ b/pkg/boot/crawl/crawl_test.go
@@ -287,6 +287,13 @@ func TestCrawler_FindPeers_wait(t *testing.T) {
 		defer h.Close()
 
 		logger := logtest.NewMockLogger(ctrl)
+		logger.EXPECT().
+			WithField(gomock.Any(), gomock.Any()).
+			Return(logger).
+			AnyTimes()
+		logger.EXPECT().
+			Trace(gomock.Any()).
+			AnyTimes()
 
 		conn := mock_net.NewMockPacketConn(ctrl)
 		conn.EXPECT().
@@ -336,6 +343,10 @@ func TestCrawler_FindPeers_wait(t *testing.T) {
 		errFail := errors.New("fail")
 
 		logger := logtest.NewMockLogger(ctrl)
+		logger.EXPECT().
+			WithField(gomock.Any(), gomock.Any()).
+			Return(logger).
+			AnyTimes()
 		logger.EXPECT().
 			WithError(errFail).
 			Return(logger).

--- a/pkg/boot/crawl/crawl_test.go
+++ b/pkg/boot/crawl/crawl_test.go
@@ -2,11 +2,13 @@ package crawl_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/libp2p/go-libp2p"
@@ -231,6 +233,154 @@ func TestCrawler_advertise(t *testing.T) {
 	<-syncReply
 }
 
+func TestCrawler_FindPeers_strategy_error(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := newTestHost()
+	defer h.Close()
+
+	logger := logtest.NewMockLogger(ctrl)
+
+	conn := mock_net.NewMockPacketConn(ctrl)
+	conn.EXPECT().
+		ReadFrom(gomock.Any()).
+		DoAndReturn(func(b []byte) (n int, a net.Addr, err error) {
+			n = copy(b, resBytes)
+			a = &net.UDPAddr{}
+			return
+		}).
+		AnyTimes()
+	conn.EXPECT().
+		Close().
+		Return(nil).
+		Times(1)
+
+	errFail := errors.New("fail")
+	fail := func() (crawl.Range, error) {
+		return nil, errFail
+	}
+
+	c := crawl.New(h, conn, fail, socket.WithLogger(logger))
+	defer func() {
+		assert.NoError(t, c.Close(), "should close gracefully")
+	}()
+
+	ch, err := c.FindPeers(context.TODO(), "test")
+	require.ErrorIs(t, err, errFail, "should return strategy error")
+	require.Nil(t, ch, "should return nil channel")
+}
+
+func TestCrawler_FindPeers_wait(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	t.Run("GracefulAbort", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		h := newTestHost()
+		defer h.Close()
+
+		logger := logtest.NewMockLogger(ctrl)
+
+		conn := mock_net.NewMockPacketConn(ctrl)
+		conn.EXPECT().
+			ReadFrom(gomock.Any()).
+			DoAndReturn(func(b []byte) (n int, a net.Addr, err error) {
+				n = copy(b, resBytes)
+				a = &net.UDPAddr{}
+				return
+			}).
+			AnyTimes()
+		conn.EXPECT().
+			Close().
+			Return(nil).
+			Times(1)
+		conn.EXPECT().
+			WriteTo(gomock.Any(), gomock.Any()).
+			Return(0, context.Canceled).
+			Times(1)
+
+		c := crawl.New(h, conn, rangeUDP(&net.UDPAddr{}), socket.WithLogger(logger))
+		defer c.Close()
+
+		ch, err := c.FindPeers(context.TODO(), "test")
+		require.NoError(t, err, "should not return error")
+		require.NotNil(t, ch, "should return valid channel")
+
+		assert.Eventually(t, func() bool {
+			select {
+			case <-ch:
+				return true
+			default:
+				return false
+			}
+		}, time.Millisecond*100, time.Millisecond*10,
+			"should close channel when error is encountered")
+	})
+
+	t.Run("SocketError", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		h := newTestHost()
+		defer h.Close()
+
+		errFail := errors.New("fail")
+
+		logger := logtest.NewMockLogger(ctrl)
+		logger.EXPECT().
+			WithError(errFail).
+			Return(logger).
+			Times(1)
+		logger.EXPECT().
+			Error("failed to send request packet").
+			Times(1)
+
+		conn := mock_net.NewMockPacketConn(ctrl)
+		conn.EXPECT().
+			ReadFrom(gomock.Any()).
+			DoAndReturn(func(b []byte) (n int, a net.Addr, err error) {
+				n = copy(b, resBytes)
+				a = &net.UDPAddr{}
+				return
+			}).
+			AnyTimes()
+		conn.EXPECT().
+			Close().
+			Return(nil).
+			Times(1)
+		conn.EXPECT().
+			WriteTo(gomock.Any(), gomock.Any()).
+			Return(0, errFail).
+			Times(1)
+
+		c := crawl.New(h, conn, rangeUDP(&net.UDPAddr{}), socket.WithLogger(logger))
+		defer c.Close()
+
+		ch, err := c.FindPeers(context.TODO(), "test")
+		require.NoError(t, err, "should not return error")
+		require.NotNil(t, ch, "should return valid channel")
+
+		assert.Eventually(t, func() bool {
+			select {
+			case <-ch:
+				return true
+			default:
+				return false
+			}
+		}, time.Millisecond*100, time.Millisecond*10,
+			"should close channel when error is encountered")
+	})
+}
+
 func TestCrawler_find_peers(t *testing.T) {
 	t.Parallel()
 
@@ -251,6 +401,13 @@ func TestCrawler_find_peers(t *testing.T) {
 	defer h.Close()
 
 	logger := logtest.NewMockLogger(ctrl)
+	logger.EXPECT().
+		WithField(gomock.Any(), gomock.Any()).
+		Return(logger).
+		AnyTimes()
+	logger.EXPECT().
+		Trace(gomock.Any()).
+		AnyTimes()
 
 	conn := mock_net.NewMockPacketConn(ctrl)
 	conn.EXPECT().


### PR DESCRIPTION
Fixes https://github.com/wetware/casm/issues/49.

The essence of the fix is just to ignore `context.Canceled` when sending request packets.  It is treated as a graceful termination of the crawl.

`context.DeadlineExceeded` is usually a graceful termination as well, but this is application dependent.  We therefore log this event at `DEBUG` level, to facilitate debugging for application developers.