### PR TITLE
Add support for dialing a specific host:port tuple in bootutil.

### DIFF
--- a/pkg/boot/util/util.go
+++ b/pkg/boot/util/util.go
@@ -3,7 +3,9 @@ package bootutil
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/libp2p/go-libp2p/core/discovery"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -48,6 +50,9 @@ func Dial(h host.Host, maddr ma.Multiaddr, opt ...socket.Option) (discovery.Disc
 		}
 
 		return s, nil
+
+	case IsPortRange(maddr):
+		return DialPortRange(h, maddr, opt...)
 	}
 
 	return nil, ErrUnknownBootProto
@@ -84,30 +89,11 @@ func Listen(h host.Host, maddr ma.Multiaddr, opt ...socket.Option) (discovery.Di
 }
 
 func DialCIDR(h host.Host, maddr ma.Multiaddr, opt ...socket.Option) (*crawl.Crawler, error) {
-	return newCrawler(h, maddr, func(m ma.Multiaddr) (net.PacketConn, error) {
-		network, _, err := manet.DialArgs(maddr)
-		if err != nil {
-			return nil, err
-		}
-
-		return net.ListenPacket(network, ":0")
-	}, opt)
+	return newCIDRCrawler(h, maddr, dial, opt)
 }
 
 func ListenCIDR(h host.Host, maddr ma.Multiaddr, opt ...socket.Option) (*crawl.Crawler, error) {
-	return newCrawler(h, maddr, func(m ma.Multiaddr) (net.PacketConn, error) {
-		network, address, err := manet.DialArgs(maddr)
-		if err != nil {
-			return nil, err
-		}
-
-		_, port, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, err
-		}
-
-		return net.ListenPacket(network, ":"+port)
-	}, opt)
+	return newCIDRCrawler(h, maddr, listen, opt)
 }
 
 func DialMulticast(h host.Host, maddr ma.Multiaddr, opt ...socket.Option) (*survey.Surveyor, error) {
@@ -122,6 +108,34 @@ func DialMulticast(h host.Host, maddr ma.Multiaddr, opt ...socket.Option) (*surv
 	}
 
 	return survey.New(h, conn, opt...), nil
+}
+
+func DialPortRange(h host.Host, maddr ma.Multiaddr, opt ...socket.Option) (*crawl.Crawler, error) {
+	_, addr, err := manet.DialArgs(maddr)
+	if err != nil {
+		return nil, err
+	}
+
+	ipstr, portstr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	ip := net.ParseIP(ipstr)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP: %s", ipstr)
+	}
+
+	port, err := strconv.Atoi(portstr)
+	if err != nil {
+		return nil, err
+	}
+
+	return crawlerFactory{
+		Host:     h,
+		Strategy: crawl.NewPortRange(ip, port, port),
+		NewConn:  dial,
+	}.New(maddr, opt)
 }
 
 func IsP2P(maddr ma.Multiaddr) bool {
@@ -140,6 +154,27 @@ func IsSurvey(maddr ma.Multiaddr) bool {
 	return hasBootProto(maddr, survey.P_SURVEY)
 }
 
+// IsPortRange returns true if maddr is a UDP address with no subprotocols.
+// This function MAY be extended to support port ranges ranges in the near
+// future.
+func IsPortRange(maddr ma.Multiaddr) bool {
+	var n int
+	ma.ForEach(maddr, func(ma.Component) bool {
+		n++
+		return true
+	})
+
+	// are there more than two components?
+	if n > 2 {
+		return false
+	}
+
+	// are the components not ip & udp?
+	hasIP := hasBootProto(maddr, ma.P_IP4) || hasBootProto(maddr, ma.P_IP6)
+	hasUDP := hasBootProto(maddr, ma.P_UDP)
+	return hasIP && hasUDP
+}
+
 func hasBootProto(maddr ma.Multiaddr, code int) bool {
 	for _, p := range maddr.Protocols() {
 		if p.Code == code {
@@ -150,18 +185,55 @@ func hasBootProto(maddr ma.Multiaddr, code int) bool {
 	return false
 }
 
+func dial(maddr ma.Multiaddr) (net.PacketConn, error) {
+	network, _, err := manet.DialArgs(maddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return net.ListenPacket(network, ":0")
+}
+
+func listen(maddr ma.Multiaddr) (net.PacketConn, error) {
+	network, address, err := manet.DialArgs(maddr)
+	if err != nil {
+		return nil, err
+	}
+
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return net.ListenPacket(network, ":"+port)
+}
+
 type packetFunc func(ma.Multiaddr) (net.PacketConn, error)
 
-func newCrawler(h host.Host, maddr ma.Multiaddr, newConn packetFunc, opt []socket.Option) (*crawl.Crawler, error) {
+func newCIDRCrawler(h host.Host, maddr ma.Multiaddr, newConn packetFunc, opt []socket.Option) (*crawl.Crawler, error) {
 	s, err := crawl.ParseCIDR(maddr)
 	if err != nil {
 		return nil, err
 	}
 
-	conn, err := newConn(maddr)
+	return crawlerFactory{
+		Host:     h,
+		Strategy: s,
+		NewConn:  newConn,
+	}.New(maddr, opt)
+}
+
+type crawlerFactory struct {
+	Host     host.Host
+	Strategy crawl.Strategy
+	NewConn  packetFunc
+}
+
+func (c crawlerFactory) New(addr ma.Multiaddr, opt []socket.Option) (*crawl.Crawler, error) {
+	conn, err := c.NewConn(addr)
 	if err != nil {
 		return nil, err
 	}
 
-	return crawl.New(h, conn, s, opt...), nil
+	return crawl.New(c.Host, conn, c.Strategy, opt...), nil
 }

--- a/pkg/boot/util/util_test.go
+++ b/pkg/boot/util/util_test.go
@@ -1,0 +1,88 @@
+package bootutil_test
+
+import (
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	bootutil "github.com/wetware/casm/pkg/boot/util"
+)
+
+func TestIsCIDR(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	for _, tt := range []struct {
+		name string
+		addr ma.Multiaddr
+		want bool
+	}{
+		{name: "IPv4", addr: ma.StringCast("/ip4/10.0.1.0/udp/8822/cidr/24"), want: true},
+		{name: "IPv6", addr: ma.StringCast("/ip6/2001:ff::/udp/8822/cidr/110"), want: true},
+		{name: "Fail", addr: ma.StringCast("/ip6/2001:ff::/udp/8822"), want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bootutil.IsCIDR(tt.addr))
+		})
+	}
+}
+
+func TestIsMulticast(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	for _, tt := range []struct {
+		name string
+		addr ma.Multiaddr
+		want bool
+	}{
+		{name: "IPv4", addr: ma.StringCast("/ip4/10.0.1.0/udp/8822/multicast/lo0"), want: true},
+		{name: "IPv6", addr: ma.StringCast("/ip6/2001:ff::/udp/8822/multicast/lo0"), want: true},
+		{name: "IPv4/Survey", addr: ma.StringCast("/ip4/10.0.1.0/udp/8822/multicast/lo0/survey"), want: true},
+		{name: "IPv6/Survey", addr: ma.StringCast("/ip6/2001:ff::/udp/8822/multicast/lo0/survey"), want: true},
+		{name: "Fail", addr: ma.StringCast("/ip6/2001:ff::/udp/8822"), want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bootutil.IsMulticast(tt.addr))
+		})
+	}
+}
+
+func TestIsSurvey(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	for _, tt := range []struct {
+		name string
+		addr ma.Multiaddr
+		want bool
+	}{
+		{name: "IPv4", addr: ma.StringCast("/ip4/10.0.1.0/udp/8822/multicast/lo0/survey"), want: true},
+		{name: "IPv6", addr: ma.StringCast("/ip6/2001:ff::/udp/8822/multicast/lo0/survey"), want: true},
+		{name: "Fail", addr: ma.StringCast("/ip6/2001:ff::/udp/8822/multicast/lo0"), want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bootutil.IsSurvey(tt.addr))
+		})
+	}
+}
+
+func TestIsPortRange(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	for _, tt := range []struct {
+		name string
+		addr ma.Multiaddr
+		want bool
+	}{
+		{name: "IPv4", addr: ma.StringCast("/ip4/10.0.1.0/udp/8822"), want: true},
+		{name: "IPv6", addr: ma.StringCast("/ip6/2001:ff::/udp/8822"), want: true},
+		{name: "TCP", addr: ma.StringCast("/ip4/10.0.1.0/tcp/8822"), want: false},
+		{name: "Subprotocol", addr: ma.StringCast("/ip4/10.0.1.0/udp/8822/quic"), want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bootutil.IsPortRange(tt.addr))
+		})
+	}
+}


### PR DESCRIPTION
Uses crawl.PortRange with a single port.