### PR TITLE
Move routing.ID to casm.ID.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.23.7
-	go.uber.org/atomic v1.10.0
 	go.uber.org/multierr v1.9.0
 	golang.org/x/net v0.4.0
 	golang.org/x/time v0.3.0
@@ -116,12 +115,12 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect
 	go.uber.org/fx v1.18.2 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
-	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,6 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/internal/mock/libp2p/libp2p.go
+++ b/internal/mock/libp2p/libp2p.go
@@ -264,6 +264,20 @@ func (mr *MockConnMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConn)(nil).Close))
 }
 
+// ConnState mocks base method.
+func (m *MockConn) ConnState() network.ConnectionState {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnState")
+	ret0, _ := ret[0].(network.ConnectionState)
+	return ret0
+}
+
+// ConnState indicates an expected call of ConnState.
+func (mr *MockConnMockRecorder) ConnState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnState", reflect.TypeOf((*MockConn)(nil).ConnState))
+}
+
 // GetStreams mocks base method.
 func (m *MockConn) GetStreams() []network.Stream {
 	m.ctrl.T.Helper()

--- a/internal/mock/pkg/cluster/routing/routing.go
+++ b/internal/mock/pkg/cluster/routing/routing.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	peer "github.com/libp2p/go-libp2p/core/peer"
+	casm "github.com/wetware/casm/pkg"
 	routing "github.com/wetware/casm/pkg/cluster/routing"
 )
 
@@ -95,10 +96,10 @@ func (mr *MockRecordMockRecorder) Seq() *gomock.Call {
 }
 
 // Server mocks base method.
-func (m *MockRecord) Server() routing.ID {
+func (m *MockRecord) Server() casm.ID {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Server")
-	ret0, _ := ret[0].(routing.ID)
+	ret0, _ := ret[0].(casm.ID)
 	return ret0
 }
 

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -210,7 +210,7 @@ func (r clientRecord) PeerBytes() ([]byte, error) {
 	return api.View_Record(r).PeerBytes()
 }
 
-func (r clientRecord) Server() routing.ID {
+func (r clientRecord) Server() casm.ID {
 	return r.heartbeat().Server()
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/lthibault/jitterbug/v2"
 	"github.com/lthibault/log"
+	casm "github.com/wetware/casm/pkg"
 	"github.com/wetware/casm/pkg/cluster/pulse"
 	"github.com/wetware/casm/pkg/cluster/routing"
 )
@@ -39,6 +40,7 @@ type RoutingTable interface {
 // It maintains a global view of the cluster with PA/EL guarantees,
 // and periodically announces its presence to others.
 type Router struct {
+	ID    casm.ID
 	Topic Topic
 
 	Log          log.Logger
@@ -63,14 +65,9 @@ func (r *Router) String() string {
 	return r.Topic.String()
 }
 
-func (r *Router) ID() (id routing.ID) {
-	r.setup()
-	return routing.ID(r.id)
-}
-
 func (r *Router) Loggable() map[string]any {
 	return map[string]any{
-		"server": r.ID(),
+		"server": r.ID,
 		"ttl":    r.TTL,
 		"ns":     r.String(),
 	}
@@ -200,7 +197,7 @@ func (r *Router) heartbeat() {
 
 	hb := pulse.NewHeartbeat()
 	hb.SetTTL(r.TTL)
-	hb.SetServer(r.ID())
+	hb.SetServer(r.ID)
 
 	for a := range r.announce {
 		err := r.emit(r.Clock.Context(), hb, a)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -40,14 +40,20 @@ type RoutingTable interface {
 // It maintains a global view of the cluster with PA/EL guarantees,
 // and periodically announces its presence to others.
 type Router struct {
+	// required fields
+
 	ID    casm.ID
 	Topic Topic
+
+	// optional fields
 
 	Log          log.Logger
 	TTL          time.Duration
 	Meta         pulse.Preparer
 	Clock        Clock
 	RoutingTable RoutingTable
+
+	// private fields
 
 	mu             sync.Mutex
 	init, relaying atomic.Bool

--- a/pkg/cluster/pulse/heartbeat.go
+++ b/pkg/cluster/pulse/heartbeat.go
@@ -7,6 +7,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 
 	api "github.com/wetware/casm/internal/api/routing"
+	casm "github.com/wetware/casm/pkg"
 	"github.com/wetware/casm/pkg/cluster/routing"
 )
 
@@ -40,12 +41,12 @@ func (h Heartbeat) TTL() (d time.Duration) {
 	return
 }
 
-func (h Heartbeat) SetServer(id routing.ID) {
+func (h Heartbeat) SetServer(id casm.ID) {
 	h.Heartbeat.SetServer(uint64(id))
 }
 
-func (h Heartbeat) Server() routing.ID {
-	return routing.ID(h.Heartbeat.Server())
+func (h Heartbeat) Server() casm.ID {
+	return casm.ID(h.Heartbeat.Server())
 }
 
 func (h Heartbeat) Meta() (routing.Meta, error) {

--- a/pkg/cluster/query.go
+++ b/pkg/cluster/query.go
@@ -7,6 +7,7 @@ import (
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p/core/peer"
 	api "github.com/wetware/casm/internal/api/routing"
+	casm "github.com/wetware/casm/pkg"
 	"github.com/wetware/casm/pkg/cluster/routing"
 )
 
@@ -87,7 +88,7 @@ func bindServer(target api.View_Index, index routing.Index) error {
 		}
 		return err
 
-	case interface{ Server() routing.ID }:
+	case interface{ Server() casm.ID }:
 		index, err := ix.Server().MarshalText()
 		if err == nil {
 			defer pool.Put(index)

--- a/pkg/cluster/query/selector_test.go
+++ b/pkg/cluster/query/selector_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mock_routing "github.com/wetware/casm/internal/mock/pkg/cluster/routing"
+	casm "github.com/wetware/casm/pkg"
 	"github.com/wetware/casm/pkg/cluster/query"
 	"github.com/wetware/casm/pkg/cluster/routing"
 )
@@ -167,7 +168,7 @@ type record struct {
 	once sync.Once
 	id   peer.ID
 	seq  uint64
-	ins  uint64
+	ins  casm.ID
 	host string
 	meta routing.Meta
 	ttl  time.Duration
@@ -184,7 +185,7 @@ func (r *record) init() {
 		}
 
 		if r.ins == 0 {
-			r.ins = rand.Uint64()
+			r.ins = casm.ID(rand.Uint64())
 		}
 	})
 }
@@ -194,9 +195,9 @@ func (r *record) Peer() peer.ID {
 	return r.id
 }
 
-func (r *record) Server() routing.ID {
+func (r *record) Server() casm.ID {
 	r.init()
-	return routing.ID(r.ins)
+	return r.ins
 }
 
 func (r *record) Seq() uint64 { return r.seq }

--- a/pkg/cluster/routing/routing.go
+++ b/pkg/cluster/routing/routing.go
@@ -3,74 +3,18 @@
 package routing
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"strings"
 	"time"
-	"unsafe"
 
 	"capnproto.org/go/capnp/v3"
-	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p/core/peer"
+	casm "github.com/wetware/casm/pkg"
 )
-
-// ID is an opaque identifier that identifies a unique host instance
-// on the network.   A fresh ID is generated for each cluster.Router
-// instance, making it possible to distinguish between multiple runs
-// of a libp2p host with a fixed peer identity.
-//
-// IDs are not guaranteed to be globally unique.
-type ID uint64
-
-func (id ID) String() string {
-	b := id.Bytes()
-	defer pool.Put(b)
-
-	buf := pool.Get(16)
-	hex.Encode(buf, b)
-
-	return *(*string)(unsafe.Pointer(&buf))
-}
-
-func (id ID) Bytes() []byte {
-	buf := pool.Get(8)
-	binary.BigEndian.PutUint64(buf, uint64(id))
-	return buf
-}
-
-func (id *ID) UnmarshalText(b []byte) error {
-	buf := pool.Get(8)
-	defer pool.Put(buf)
-
-	_, err := hex.Decode(buf, b)
-	if err == nil {
-		*id = ID(binary.BigEndian.Uint64(buf))
-	}
-
-	return err
-}
-
-func (id ID) MarshalText() ([]byte, error) {
-	b := pool.Get(16)
-	binary.BigEndian.PutUint64(b, uint64(id))
-
-	buf := id.Bytes()
-	defer pool.Put(buf)
-
-	hex.Encode(b, buf)
-	return b, nil
-}
-
-func (id ID) Loggable() map[string]any {
-	return map[string]any{
-		"server": id,
-	}
-}
 
 // Record is an entry in the routing table.
 type Record interface {
-	Server() ID
+	Server() casm.ID
 	Peer() peer.ID
 	Seq() uint64
 	TTL() time.Duration

--- a/pkg/cluster/routing/routing_test.go
+++ b/pkg/cluster/routing/routing_test.go
@@ -1,57 +1,17 @@
 package routing_test
 
 import (
-	"bytes"
 	"crypto/rand"
-	"encoding/json"
 	"testing"
 	"time"
 
-	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/wetware/casm/pkg/cluster/routing"
 )
 
 var t0 = time.Date(2020, 4, 9, 8, 0, 0, 0, time.UTC)
-
-func TestID(t *testing.T) {
-	t.Parallel()
-
-	var id = routing.ID(42)
-	assert.Len(t, id.Bytes(), 8)
-	assert.Len(t, id.String(), 16)
-
-	var buf bytes.Buffer
-	err := json.NewEncoder(&buf).Encode(id)
-	require.NoError(t, err, "should marshal JSON")
-
-	var got routing.ID
-	err = json.NewDecoder(&buf).Decode(&got)
-	require.NoError(t, err, "should unmarshal JSON")
-
-	assert.Equal(t, id, got)
-}
-
-func BenchmarkID(b *testing.B) {
-	b.ReportAllocs()
-
-	var id = routing.ID(42)
-	b.Run("String", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_ = id.String()
-		}
-	})
-
-	b.Run("Bytes", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			buf := id.Bytes()
-			pool.Put(buf)
-		}
-	})
-}
 
 func TestMetaField(t *testing.T) {
 	t.Parallel()

--- a/pkg/cluster/routing/schema.go
+++ b/pkg/cluster/routing/schema.go
@@ -11,6 +11,7 @@ import (
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p/core/peer"
 	b58 "github.com/mr-tron/base58/base58"
+	casm "github.com/wetware/casm/pkg"
 )
 
 func schema() *memdb.TableSchema {
@@ -120,7 +121,7 @@ func (serverIndexer) FromArgs(args ...any) ([]byte, error) {
 	case Record:
 		return arg.Server().MarshalText()
 
-	case ID:
+	case casm.ID:
 		return arg.MarshalText()
 
 	case string:

--- a/pkg/cluster/routing/schema_test.go
+++ b/pkg/cluster/routing/schema_test.go
@@ -2,7 +2,6 @@ package routing
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"math/rand"
 	"testing"
 	"time"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	casm "github.com/wetware/casm/pkg"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,11 +118,8 @@ func BenchmarkIDIndexer(b *testing.B) {
 func TestServerIndexer(t *testing.T) {
 	t.Parallel()
 
-	id := ID(rand.Uint64())
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, uint64(id))
-	want := make([]byte, 16)
-	hex.Encode(want, buf)
+	id := casm.ID(rand.Uint64())
+	want, _ := id.MarshalText()
 
 	t.Run("FromObject", func(t *testing.T) {
 		t.Helper()
@@ -199,7 +196,7 @@ func BenchmarkServerIndexer(b *testing.B) {
 	b.ReportAllocs()
 
 	b.Run("FromObject", func(b *testing.B) {
-		rec := &testRecord{server: ID(rand.Uint64())}
+		rec := &testRecord{server: casm.ID(rand.Uint64())}
 
 		for i := 0; i < b.N; i++ {
 			_, _, _ = serverIndexer{}.FromObject(rec)
@@ -266,7 +263,7 @@ func BenchmarkTimeIndexer(b *testing.B) {
 	b.ReportAllocs()
 
 	rec := &record{
-		Record:   &testRecord{server: ID(rand.Uint64())},
+		Record:   &testRecord{server: casm.ID(rand.Uint64())},
 		Deadline: time.Date(2020, 01, 01, 01, 01, 01, 01, time.UTC),
 	}
 
@@ -389,7 +386,7 @@ func (t peerIndex) PeerBytes() ([]byte, error) {
 }
 
 type serverIndex struct {
-	id     ID
+	id     casm.ID
 	prefix bool
 }
 
@@ -402,7 +399,7 @@ func (t serverIndex) ServerBytes() ([]byte, error) {
 
 type testRecord struct {
 	peer   peer.ID
-	server ID
+	server casm.ID
 	seq    uint64
 	host   string
 	meta   Meta
@@ -411,7 +408,7 @@ type testRecord struct {
 
 func (r testRecord) Peer() peer.ID         { return r.peer }
 func (r testRecord) Seq() uint64           { return r.seq }
-func (r testRecord) Server() ID            { return ID(r.server) }
+func (r testRecord) Server() casm.ID       { return casm.ID(r.server) }
 func (r testRecord) Host() (string, error) { return r.host, nil }
 func (r testRecord) Meta() (Meta, error)   { return r.meta, nil }
 

--- a/pkg/cluster/view_test.go
+++ b/pkg/cluster/view_test.go
@@ -18,6 +18,7 @@ import (
 
 	mock_cluster "github.com/wetware/casm/internal/mock/pkg/cluster"
 	mock_routing "github.com/wetware/casm/internal/mock/pkg/cluster/routing"
+	casm "github.com/wetware/casm/pkg"
 	"github.com/wetware/casm/pkg/cluster"
 	"github.com/wetware/casm/pkg/cluster/routing"
 )
@@ -221,7 +222,7 @@ type record struct {
 	once sync.Once
 	id   peer.ID
 	seq  uint64
-	ins  uint64
+	ins  casm.ID
 	host string
 	meta routing.Meta
 	ttl  time.Duration
@@ -238,7 +239,7 @@ func (r *record) init() {
 		}
 
 		if r.ins == 0 {
-			r.ins = rand.Uint64()
+			r.ins = casm.ID(rand.Uint64())
 		}
 	})
 }
@@ -248,9 +249,9 @@ func (r *record) Peer() peer.ID {
 	return r.id
 }
 
-func (r *record) Server() routing.ID {
+func (r *record) Server() casm.ID {
 	r.init()
-	return routing.ID(r.ins)
+	return casm.ID(r.ins)
 }
 
 func (r *record) Seq() uint64 { return r.seq }

--- a/pkg/vat_test.go
+++ b/pkg/vat_test.go
@@ -1,7 +1,9 @@
 package casm_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -22,6 +24,33 @@ import (
 	testing_api "github.com/wetware/casm/internal/api/testing"
 	casm "github.com/wetware/casm/pkg"
 )
+
+func TestID(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	var id = casm.ID(42)
+
+	t.Run("Format", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Len(t, id.Bytes(), 8, "should be 8 bytes long")
+		assert.Len(t, id.String(), 16, "should be string of length 16")
+	})
+
+	t.Run("JSON", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		err := json.NewEncoder(&buf).Encode(id)
+		require.NoError(t, err, "should marshal JSON")
+
+		var got casm.ID
+		err = json.NewDecoder(&buf).Decode(&got)
+		require.NoError(t, err, "should unmarshal JSON")
+		assert.Equal(t, id, got, "IDs should be equal")
+	})
+}
 
 func TestVat(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Precursor to implementing wetware anchors.