### PR TITLE
Remove go.uber.org/atomic usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/pkg/cluster/routing/schema.go
+++ b/pkg/cluster/routing/schema.go
@@ -13,7 +13,7 @@ import (
 	b58 "github.com/mr-tron/base58/base58"
 )
 
-func schema(clock *Clock) *memdb.TableSchema {
+func schema() *memdb.TableSchema {
 	return &memdb.TableSchema{
 		Name: "record",
 		Indexes: map[string]*memdb.IndexSchema{

--- a/pkg/cluster/routing/schema.go
+++ b/pkg/cluster/routing/schema.go
@@ -11,10 +11,9 @@ import (
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p/core/peer"
 	b58 "github.com/mr-tron/base58/base58"
-	"go.uber.org/atomic"
 )
 
-func schema(clock *atomic.Time) *memdb.TableSchema {
+func schema(clock *Clock) *memdb.TableSchema {
 	return &memdb.TableSchema{
 		Name: "record",
 		Indexes: map[string]*memdb.IndexSchema{

--- a/pkg/cluster/routing/table.go
+++ b/pkg/cluster/routing/table.go
@@ -7,38 +7,38 @@ import (
 	"github.com/wetware/casm/pkg/stm"
 )
 
-type Clock struct {
+type clock struct {
 	time time.Time
 	mu   sync.RWMutex
 }
 
 type Table struct {
-	clock   *Clock
+	clock   *clock
 	records stm.TableRef
 	sched   stm.Scheduler
 }
 
-func (c *Clock) Load() time.Time {
+func (c *clock) Load() time.Time {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.time
 }
 
-func (c *Clock) Store(val time.Time) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+func (c *clock) Store(val time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.time = val
 }
 
 func New(t0 time.Time) Table {
 	var (
 		f     stm.Factory
-		clock = &Clock{
+		clock = &clock{
 			time: t0,
 		}
 	)
 
-	records := f.Register("record", schema(clock))
+	records := f.Register("record", schema())
 	sched, err := f.NewScheduler() // no err since f is freshly instantiated
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- Simple implementation of sync.RWMutex to add reader and writer locks to replace the atomic operations. 
- Confused why schema.go needed the atomic.time since it wasn't used. I just changed it to *Clock, but it looks like it could just be removed. 