### PR TITLE
Replace function with global for routing table schema.

### DIFF
--- a/pkg/cluster/routing/schema.go
+++ b/pkg/cluster/routing/schema.go
@@ -13,36 +13,34 @@ import (
 	b58 "github.com/mr-tron/base58/base58"
 )
 
-func schema() *memdb.TableSchema {
-	return &memdb.TableSchema{
-		Name: "record",
-		Indexes: map[string]*memdb.IndexSchema{
-			"id": {
-				Name:    "id",
-				Unique:  true,
-				Indexer: idIndexer{},
-			},
-			"server": {
-				Name:    "server",
-				Unique:  true,
-				Indexer: serverIndexer{},
-			},
-			"ttl": {
-				Name:    "ttl",
-				Indexer: timeIndexer{},
-			},
-			"host": {
-				Name:         "host",
-				AllowMissing: true,
-				Indexer:      hostnameIndexer{},
-			},
-			"meta": {
-				Name:         "meta",
-				AllowMissing: true,
-				Indexer:      metaIndexer{},
-			},
+var schema = memdb.TableSchema{
+	Name: "record",
+	Indexes: map[string]*memdb.IndexSchema{
+		"id": {
+			Name:    "id",
+			Unique:  true,
+			Indexer: idIndexer{},
 		},
-	}
+		"server": {
+			Name:    "server",
+			Unique:  true,
+			Indexer: serverIndexer{},
+		},
+		"ttl": {
+			Name:    "ttl",
+			Indexer: timeIndexer{},
+		},
+		"host": {
+			Name:         "host",
+			AllowMissing: true,
+			Indexer:      hostnameIndexer{},
+		},
+		"meta": {
+			Name:         "meta",
+			AllowMissing: true,
+			Indexer:      metaIndexer{},
+		},
+	},
 }
 
 type idIndexer struct{}

--- a/pkg/cluster/routing/table.go
+++ b/pkg/cluster/routing/table.go
@@ -38,7 +38,7 @@ func New(t0 time.Time) Table {
 		}
 	)
 
-	records := f.Register("record", schema())
+	records := f.Register("record", &schema)
 	sched, err := f.NewScheduler() // no err since f is freshly instantiated
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This is a minor simplification that replaces the function previously used to construct the routing table's schema with a static global.   There are no functional changes.