### PR TITLE
Update protoutil.MatchFunc to receive protocol.ID as input.

### DIFF
--- a/pkg/casm.go
+++ b/pkg/casm.go
@@ -148,13 +148,13 @@ var (
 // MatchPacked returns true if the supplied protocol.ID requires
 // a packed Cap'n Proto transport.
 func MatchPacked(id protocol.ID) bool {
-	return packedProt.MatchProto(id)
+	return packedProt.Match(id)
 }
 
 // MatchLz4 returns true if the supplied protocol.ID requires
 // a Lz4 compressed Cap'n Proto transport.
 func MatchLz4(id protocol.ID) bool {
-	return lz4Prot.MatchProto(id)
+	return lz4Prot.Match(id)
 }
 
 type Lz4Stream struct {

--- a/pkg/casm_test.go
+++ b/pkg/casm_test.go
@@ -15,7 +15,7 @@ func TestProto(t *testing.T) {
 	matcher := casm.NewMatcher(ns)
 	proto := casm.Subprotocol(ns)
 
-	assert.True(t, matcher.MatchProto(proto),
+	assert.True(t, matcher.Match(proto),
 		"matcher should match subprotocol")
 }
 

--- a/pkg/util/proto/match.go
+++ b/pkg/util/proto/match.go
@@ -10,8 +10,8 @@ import (
 
 type MatchFunc func(string) (string, bool)
 
-func (f MatchFunc) Match(s string) bool {
-	_, ok := f(s)
+func (f MatchFunc) Match(id protocol.ID) bool {
+	_, ok := f(string(id))
 	return ok
 }
 
@@ -35,10 +35,6 @@ func Match(ms ...MatchFunc) (f MatchFunc) {
 	}
 
 	return
-}
-
-func (f MatchFunc) MatchProto(id protocol.ID) bool {
-	return f.Match(string(id))
 }
 
 func Exactly(s string) MatchFunc {

--- a/pkg/util/proto/match_test.go
+++ b/pkg/util/proto/match_test.go
@@ -160,7 +160,7 @@ type matcherTest struct {
 
 func (mt matcherTest) Run(t *testing.T) {
 	t.Run(mt.name, func(t *testing.T) {
-		if match := mt.matcher.MatchProto(mt.input); mt.expectNoMatch {
+		if match := mt.matcher.Match(mt.input); mt.expectNoMatch {
 			assert.False(t, match, "should not match '%s'", mt.input)
 		} else {
 			assert.True(t, match, "should match '%s'", mt.input)


### PR DESCRIPTION
This is a follow-up to #69.  libp2p v0.25.1 now uniformly deals in `protocol.ID` in the stream matching API.