### PR TITLE
Remove casm.FuturePtr

### DIFF
--- a/pkg/rpc.go
+++ b/pkg/rpc.go
@@ -28,52 +28,6 @@ func (f Future) Await(ctx context.Context) error {
 	return f.Err()
 }
 
-type FuturePtr struct{ *capnp.Future }
-
-func (f FuturePtr) Client() capnp.Client {
-	ptr, err := f.Ptr()
-	if err != nil {
-		return capnp.ErrorClient(err)
-	}
-
-	return ptr.Interface().Client()
-}
-
-func (f FuturePtr) Await(ctx context.Context) (capnp.Ptr, error) {
-	select {
-	case <-f.Done():
-	case <-ctx.Done():
-	}
-
-	// The future may have resolved due to a canceled context, in which
-	// case there is a race-condition in the above select.
-	if ctx.Err() != nil {
-		return capnp.Ptr{}, ctx.Err()
-	}
-
-	return f.Ptr()
-}
-
-func (f FuturePtr) AwaitBytes(ctx context.Context) ([]byte, error) {
-	ptr, err := f.Await(ctx)
-	return ptr.Data(), err
-}
-
-func (f FuturePtr) AwaitString(ctx context.Context) (string, error) {
-	ptr, err := f.Await(ctx)
-	return ptr.Text(), err
-}
-
-func (f FuturePtr) Bytes() ([]byte, error) {
-	ptr, err := f.Ptr()
-	return ptr.Data(), err
-}
-
-func (f FuturePtr) String() (string, error) {
-	ptr, err := f.Ptr()
-	return ptr.Text(), err
-}
-
 type Iterator[T any] struct {
 	Seq interface {
 		Next() (T, bool)


### PR DESCRIPTION
`casm.FuturePtr` is broken by design, and is responsible for a bug in the ongoing development of Wetware channels.  `FuturePtr` casts the _results_ struct as a pointer, whereas the desired behavior is to cast a particular _field of the results struct_ as a pointer.  Because we can't know in in general how many return values are produced by a method call, there is no way to create a generic `FuturePtr`.

